### PR TITLE
建築物プレハブの保存パスの取得方法の修正

### DIFF
--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Editor/BuildingMeshUtility.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Editor/BuildingMeshUtility.cs
@@ -1,47 +1,45 @@
-using PlateauToolkit.Sandbox.Editor;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UnityEditor;
-using UnityEditor.PackageManager.UI;
 using UnityEngine;
 
 namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
 {
     public static class BuildingMeshUtility
     {
-        public static string GetMeshAssetsFolderPath()
+        private static string GetMeshAssetsFolderPath(string prefabPath)
         {
-            return GetAssetsFolderPath("Meshes");
-        }
-
-        public static string GetPrefabAssetsFolderPath()
-        {
-            return GetAssetsFolderPath("Prefabs");
-        }
-
-        private static string GetAssetsFolderPath(string folderName)
-        {
-            bool res = PlateauSandboxAssetUtility.GetSample(out Sample sample);
-            if (res == false)
+            // ルートパスの場合はnull
+            string prefabFolderPath = Path.GetDirectoryName(prefabPath);
+            if (prefabFolderPath == null)
             {
-                Debug.LogError($"{folderName} assets folder directory is not exist.");
-                return Path.Combine("Assets/Samples/PLATEAU SDK-Toolkits for Unity/0.0.0/Sample Assets", folderName).Replace("\\", "/");
+                 return Path.Combine(prefabPath, "Meshes");
             }
-
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
-            string assetsFolderPath = Path.Combine("Assets", sample.importPath.Split(@"/Assets/")[1], $"Buildings/{folderName}").Replace("\\", "/");
+            int lastSlashIndex = directoryName.LastIndexOf('/');
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
-            string assetsFolderPath = Path.Combine("Assets", sample.importPath.Split(@"\Assets\")[1], $"Buildings/{folderName}").Replace("\\", "/");
+            int lastSlashIndex = prefabFolderPath.LastIndexOf('\\');
 #endif
-            if (!Directory.Exists(assetsFolderPath))
+            string parentDirectoryName = prefabFolderPath.Substring(0, lastSlashIndex);
+            string meshAssetsFolderPath = Path.Combine(parentDirectoryName, "Meshes");
+            if (!Directory.Exists(meshAssetsFolderPath))
             {
-                Directory.CreateDirectory(assetsFolderPath);
+                Directory.CreateDirectory(meshAssetsFolderPath);
             }
-            return assetsFolderPath;
+
+            return meshAssetsFolderPath;
         }
 
-        public static bool SaveMesh(List<MeshFilter> inLsMeshFilter, string inMeshNamePrefix)
+        public static string GetMeshNamePrefix(string prefabFolderPath, string prefixBuildingName, bool isIncrementAssetName)
+        {
+            string[] files = Directory.GetFiles(prefabFolderPath, prefixBuildingName + "*.prefab", SearchOption.TopDirectoryOnly);
+            int count = isIncrementAssetName ? 1 + files.Length : files.Length;
+
+            return $"{prefixBuildingName}_{count:D2}";
+        }
+
+        public static bool SaveMesh(string prefabPath, string prefixBuildingName, List<MeshFilter> inLsMeshFilter, bool isIncrementAssetName = false)
         {
             if (inLsMeshFilter.Select(meshFilter => meshFilter.sharedMesh).Any(sharedMesh => sharedMesh == null))
             {
@@ -49,12 +47,7 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
                 return false;
             }
 
-            string meshAssetsFolderPath = GetMeshAssetsFolderPath();
-            if (!Directory.Exists(meshAssetsFolderPath))
-            {
-                Directory.CreateDirectory(meshAssetsFolderPath);
-            }
-
+            string meshAssetsFolderPath = GetMeshAssetsFolderPath(prefabPath);
             foreach (MeshFilter meshFilter in inLsMeshFilter)
             {
                 Transform lodObject = meshFilter.transform.parent;
@@ -69,7 +62,8 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
                 boxCollider.center = sharedMesh.bounds.center;
                 boxCollider.size = sharedMesh.bounds.size;
 
-                string newMeshAssetName = inMeshNamePrefix + "_" + meshFilter.name + "Mesh_" + lodNum;
+                string prefabFolderPath = Path.GetDirectoryName(prefabPath);
+                string newMeshAssetName = GetMeshNamePrefix(prefabFolderPath, prefixBuildingName, isIncrementAssetName) + "_" + meshFilter.name + "Mesh_" + lodNum;
                 string newMeshAssetPath = Path.Combine(meshAssetsFolderPath, newMeshAssetName + ".asset").Replace("\\", "/");
                 Mesh newMeshAsset = AssetDatabase.LoadAssetAtPath<Mesh>(newMeshAssetPath);
                 string oldMeshAssetPath = Path.Combine(meshAssetsFolderPath, sharedMesh.name + ".asset").Replace("\\", "/");

--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Editor/BuildingMeshUtility.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Editor/BuildingMeshUtility.cs
@@ -17,7 +17,7 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
                  return Path.Combine(prefabPath, "Meshes");
             }
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
-            int lastSlashIndex = directoryName.LastIndexOf('/');
+            int lastSlashIndex = prefabFolderPath.LastIndexOf('/');
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
             int lastSlashIndex = prefabFolderPath.LastIndexOf('\\');
 #endif

--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Editor/OnPrefabInstanceUpdated.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Editor/OnPrefabInstanceUpdated.cs
@@ -84,28 +84,17 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
 
         private static void SaveAssets(GameObject obj, Runtime.PlateauSandboxBuilding buildingGeneratorComponent)
         {
-            string meshAssetsFolderPath = BuildingMeshUtility.GetMeshAssetsFolderPath();
-            if (!Directory.Exists(meshAssetsFolderPath))
-            {
-                Directory.CreateDirectory(meshAssetsFolderPath);
-            }
-
-            string prefabAssetsFolderPath = BuildingMeshUtility.GetPrefabAssetsFolderPath();
-            if (!Directory.Exists(prefabAssetsFolderPath))
-            {
-                Directory.CreateDirectory(prefabAssetsFolderPath);
-            }
-
+            Runtime.PlateauSandboxBuilding prefab = PrefabUtility.GetCorrespondingObjectFromSource(buildingGeneratorComponent);
+            string prefabPath = AssetDatabase.GetAssetPath(prefab);
             var lsFacadeMeshFilter = obj.transform.GetComponentsInChildren<MeshFilter>().ToList();
-            if (BuildingMeshUtility.SaveMesh(lsFacadeMeshFilter, buildingGeneratorComponent.buildingName))
+            if (!BuildingMeshUtility.SaveMesh(prefabPath, buildingGeneratorComponent.GetBuildingName(), lsFacadeMeshFilter))
             {
-                OnPrefabInstanceUpdatedParameter.instance.canUpdate = false;
-                string prefabPath = Path.Combine(prefabAssetsFolderPath, buildingGeneratorComponent.buildingName + ".prefab").Replace("\\", "/");
-                PrefabUtility.SaveAsPrefabAssetAndConnect(obj, prefabPath, InteractionMode.AutomatedAction);
+                EditorUtility.DisplayDialog("建築物のメッシュ保存に失敗", "建築物の保存に失敗しました。建築物を再生成して下さい。", "はい");
                 return;
             }
 
-            EditorUtility.DisplayDialog("建築物のメッシュを保存", "建築物の保存に失敗しました。建築物を再生成して下さい。", "はい");
+            OnPrefabInstanceUpdatedParameter.instance.canUpdate = false;
+            PrefabUtility.SaveAsPrefabAssetAndConnect(obj, prefabPath, InteractionMode.AutomatedAction);
         }
     }
 }

--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Editor/PlateauSandboxBuildingEditor.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Editor/PlateauSandboxBuildingEditor.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
 
@@ -46,8 +45,6 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
         private SerializedProperty m_HotelVertexColorPalette;
         private SerializedProperty m_HotelVertexColorMaterialPalette;
         private SerializedProperty m_HotelMaterialPalette;
-
-        private SerializedProperty m_BuildingName;
 
         private GUIStyle m_SaveMeshBtnTextColorStyle;
 
@@ -330,7 +327,6 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
             m_Generator.facadeConstructor = (FacadeConstructor)EditorGUILayout.ObjectField("FacadeConstructor", m_Generator.facadeConstructor, typeof(ScriptableObject), allowSceneObjects: true);
             m_Generator.roofPlanner = (RoofPlanner)EditorGUILayout.ObjectField("RoofPlanner", m_Generator.roofPlanner, typeof(ScriptableObject), allowSceneObjects: true);
             m_Generator.roofConstructor = (RoofConstructor)EditorGUILayout.ObjectField("RoofConstructor", m_Generator.roofConstructor, typeof(ScriptableObject), allowSceneObjects: true);
-            m_Generator.buildingName = EditorGUILayout.TextField("Building Name", m_Generator.buildingName);
         }
 
         private bool BuildingDynamicGUI()
@@ -430,58 +426,33 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
         {
             if (!PrefabUtility.IsPartOfPrefabInstance(m_Generator.gameObject))
             {
-                EditorUtility.DisplayDialog("建築物を新規プレハブとして保存", "プレハブインスタンスに対してのみ実行可能です。", "はい");
+                EditorUtility.DisplayDialog("建築物を新規プレハブとして保存に失敗", "プレハブインスタンスに対してのみ実行可能です。", "はい");
                 return;
             }
 
-            string meshAssetsFolderPath = BuildingMeshUtility.GetMeshAssetsFolderPath();
-            if (!Directory.Exists(meshAssetsFolderPath))
-            {
-                Directory.CreateDirectory(meshAssetsFolderPath);
-            }
-
-            string prefabAssetsFolderPath = BuildingMeshUtility.GetPrefabAssetsFolderPath();
-            if (!Directory.Exists(prefabAssetsFolderPath))
-            {
-                Directory.CreateDirectory(prefabAssetsFolderPath);
-            }
-
-            Match matchRes = Regex.Match(m_Generator.buildingName, "[0-9]+$");
-            string newPrefabName;
-            if (matchRes.Success)
-            {
-                int count = 0;
-                m_Generator.buildingName = m_Generator.buildingName.Remove(matchRes.Index, matchRes.Length);
-
-                do
-                {
-                    count++;
-                    newPrefabName = m_Generator.buildingName + $"{int.Parse(matchRes.Value) + count:D2}";
-                }
-                while (File.Exists(Path.Combine(prefabAssetsFolderPath, newPrefabName + ".prefab").Replace("\\", "/")));
-
-                m_Generator.buildingName += $"{int.Parse(matchRes.Value) + count:D2}";
-            }
-            else
-            {
-                m_Generator.buildingName += "_01";
-                newPrefabName = m_Generator.buildingName;
-            }
-
+            Runtime.PlateauSandboxBuilding prefab = PrefabUtility.GetCorrespondingObjectFromSource(m_Generator);
+            string prefabPath = AssetDatabase.GetAssetPath(prefab);
             var lsFacadeMeshFilter = m_Generator.transform.GetComponentsInChildren<MeshFilter>().ToList();
-            if (!BuildingMeshUtility.SaveMesh(lsFacadeMeshFilter, newPrefabName))
+            if (!BuildingMeshUtility.SaveMesh(prefabPath, m_Generator.GetBuildingName(), lsFacadeMeshFilter, true))
             {
-                EditorUtility.DisplayDialog("建築物のメッシュを保存", "建築物の保存に失敗しました。建築物を再生成して下さい。", "はい");
+                EditorUtility.DisplayDialog("建築物のメッシュ保存に失敗", "建築物の保存に失敗しました。建築物を再生成して下さい。", "はい");
                 return;
             }
 
-            m_Generator.gameObject.name = m_Generator.buildingName;
-            string prefabPath = Path.Combine(prefabAssetsFolderPath, newPrefabName + ".prefab").Replace("\\", "/");
+            string prefabFolderPath = Path.GetDirectoryName(prefabPath);
+            if (prefabFolderPath == null)
+            {
+                EditorUtility.DisplayDialog("建築物のメッシュ保存に失敗", "保存パスが不正です。", "はい");
+                return;
+            }
+            string newPrefabName = BuildingMeshUtility.GetMeshNamePrefix(prefabFolderPath, m_Generator.GetBuildingName(), true);
+            m_Generator.gameObject.name = newPrefabName;
+            string prefabFullPath = Path.Combine(prefabFolderPath, newPrefabName + ".prefab").Replace("\\", "/");
             PrefabUtility.UnpackPrefabInstance(m_Generator.gameObject, PrefabUnpackMode.Completely, InteractionMode.AutomatedAction);
             OnPrefabInstanceUpdatedParameter.instance.canUpdate = false;
-            PrefabUtility.SaveAsPrefabAssetAndConnect(m_Generator.gameObject, prefabPath, InteractionMode.AutomatedAction);
+            PrefabUtility.SaveAsPrefabAssetAndConnect(m_Generator.gameObject, prefabFullPath, InteractionMode.AutomatedAction);
             OnPrefabInstanceUpdatedParameter.instance.canUpdate = true;
-            EditorUtility.DisplayDialog("建築物を新規プレハブとして保存", "建築物のプレハブが正常に保存されました。", "はい");
+            EditorUtility.DisplayDialog("建築物を新規プレハブとして保存に成功", "建築物のプレハブが正常に保存されました。", "はい");
         }
     }
 }

--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Editor/PlateauSandboxBuildingEditor.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Editor/PlateauSandboxBuildingEditor.cs
@@ -422,6 +422,9 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
             return false;
         }
 
+        /// <summary>
+        /// インスペクタ上のプレハブ保存ボタン押下時にコール
+        /// </summary>
         private void SavePrefab()
         {
             if (!PrefabUtility.IsPartOfPrefabInstance(m_Generator.gameObject))
@@ -449,9 +452,9 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
             m_Generator.gameObject.name = newPrefabName;
             string prefabFullPath = Path.Combine(prefabFolderPath, newPrefabName + ".prefab").Replace("\\", "/");
             PrefabUtility.UnpackPrefabInstance(m_Generator.gameObject, PrefabUnpackMode.Completely, InteractionMode.AutomatedAction);
-            OnPrefabInstanceUpdatedParameter.instance.canUpdate = false;
+            OnPrefabInstanceUpdatedParameter.instance.canUpdatePrefabInstance = false;
             PrefabUtility.SaveAsPrefabAssetAndConnect(m_Generator.gameObject, prefabFullPath, InteractionMode.AutomatedAction);
-            OnPrefabInstanceUpdatedParameter.instance.canUpdate = true;
+            OnPrefabInstanceUpdatedParameter.instance.canUpdatePrefabInstance = true;
             EditorUtility.DisplayDialog("建築物を新規プレハブとして保存に成功", "建築物のプレハブが正常に保存されました。", "はい");
         }
     }

--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Runtime/PlateauSandboxBuilding.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Runtime/PlateauSandboxBuilding.cs
@@ -61,11 +61,24 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Runtime
         public HotelConfig.VertexColorMaterialPalette hotelVertexColorMaterialPalette = new();
         public HotelConfig.MaterialPalette hotelMaterialPalette = new();
 
-        public string buildingName = "Building_Name";
         public FacadePlanner facadePlanner;
         public FacadeConstructor facadeConstructor;
         public RoofPlanner roofPlanner;
         public RoofConstructor roofConstructor;
+
+        public string GetBuildingName()
+        {
+            return buildingType switch
+            {
+                BuildingType.k_Apartment => "Apartment",
+                BuildingType.k_OfficeBuilding => "OfficeBuilding",
+                BuildingType.k_House => "House",
+                BuildingType.k_ConvenienceStore => "ConvenienceStore",
+                BuildingType.k_CommercialBuilding => "CommercialBuilding",
+                BuildingType.k_Hotel => "Hotel",
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
 
         public void GenerateMesh(int inLodNum, float inBuildingWidth, float inBuildingDepth)
         {


### PR DESCRIPTION
﻿## 関連リンク
<!-- libplateauのPR等、関連するPRがあれば書く。 -->
https://synesthesias.atlassian.net/browse/PLTSDK3-231
<br>
## 実装内容
・下記プレハブの保存方法に対応
　・プレハブOverride
　・プレハブApply
　・プレハブモード
<br>
## マージ前確認項目

## 動作確認（Win、Mac）
１．パッケージからサンプルアセットをインポート
２．Buildingsのプレハブをシーンに配置
３．建築物設定の横幅を変更する
４．インスペクタ上部のOverridesからApply Allでプレハブを保存（プレハブOverride）
５．建築物設定の横幅を変更する
６．PlateauSandboxBuildingコンポーネント右上の︙ボタンからModifiedComponentでApply to 名前で保存（プレハブApply）
７．シーン上のBuildingプレハブからプレハブモードに入る
８．建築物設定の横幅を変更する
９．プレハブモードを抜ける（プレハブモード）
<br>
## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->