### PR TITLE
一括配置時の調整と建物には配置されないように

### DIFF
--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxBulkPlaceData.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxBulkPlaceData.cs
@@ -96,7 +96,7 @@ namespace PlateauToolkit.Sandbox.Editor
             Latitude = csvData[latitudeIndex > 0 ? latitudeIndex : 0];
             Longitude = csvData[longitudeIndex > 0 ? longitudeIndex : 1];
             Height = csvData[heightIndex > 0 ? heightIndex : 2];
-            
+
             string assetType = csvData[assetTypeIndex > 0 ? assetTypeIndex : 3];
             m_AssetType = string.IsNullOrEmpty(assetType) ? "指定なし" : assetType;
 

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxPrefabPlacement.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxPrefabPlacement.cs
@@ -121,6 +121,7 @@ namespace PlateauToolkit.Sandbox.Editor
             // Send a ray downward to get the height of the collider.
             var ray = new Ray(rayStartPosition, Vector3.down);
 
+            var hitPointHeights = new List<float>();
             RaycastHit[] results = Physics.RaycastAll(ray, rayDistance);
             foreach (RaycastHit rayCastHit in results)
             {
@@ -133,9 +134,15 @@ namespace PlateauToolkit.Sandbox.Editor
                     }
 
                     // その他のオブジェクトは配置可能
-                    colliderHeight = rayCastHit.point.y;
-                    return true;
+                    hitPointHeights.Add(rayCastHit.point.y);
                 }
+            }
+
+            if (hitPointHeights.Count > 0)
+            {
+                // 一番上にヒットしたコライダーの高さを取得
+                colliderHeight = hitPointHeights.Max();
+                return true;
             }
 
             // Not found.

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxPrefabPlacement.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxPrefabPlacement.cs
@@ -20,8 +20,8 @@ namespace PlateauToolkit.Sandbox.Editor
 
         public struct PlacementContext
         {
-            public float m_Longitude;
-            public float m_Latitude;
+            public double m_Longitude;
+            public double m_Latitude;
             public float m_Height;
             public GameObject m_Prefab;
             public string m_AssetType;

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowBulkPlaceView.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowBulkPlaceView.cs
@@ -492,8 +492,8 @@ namespace PlateauToolkit.Sandbox.Editor
                     bool isIgnoreHeight = placeData.IsIgnoreHeight | m_IsIgnoreHeight;
                     var context = new PlateauSandboxPrefabPlacement.PlacementContext()
                     {
-                        m_Latitude = float.Parse(placeData.Latitude),
-                        m_Longitude = float.Parse(placeData.Longitude),
+                        m_Latitude = double.Parse(placeData.Latitude),
+                        m_Longitude = double.Parse(placeData.Longitude),
                         m_Height = isIgnoreHeight ? 0 : float.Parse(placeData.Height),
                         m_Prefab = prefab,
                         m_AssetType = placeData.AssetType,

--- a/PlateauToolkit.Sandbox/Editor/Shapefile/PlateauSandboxShapefileReader.cs
+++ b/PlateauToolkit.Sandbox/Editor/Shapefile/PlateauSandboxShapefileReader.cs
@@ -99,7 +99,7 @@ namespace PlateauToolkit.Sandbox.Editor
             {
                 double x = m_ShpReader.ReadDouble();
                 double y = m_ShpReader.ReadDouble();
-                shape.Points.Add(new Vector3((float)x, 0f, (float)y));
+                shape.Points.Add((x, 0, y));
             }
 
 
@@ -113,7 +113,7 @@ namespace PlateauToolkit.Sandbox.Editor
             double y = m_ShpReader.ReadDouble();
 
             // Create and return the PointShape.
-            return new PointShape(new Vector3((float)x, 0f, (float)y));
+            return new PointShape((x, 0, y));
         }
 
 
@@ -138,7 +138,7 @@ namespace PlateauToolkit.Sandbox.Editor
             {
                 double x = m_ShpReader.ReadDouble();
                 double y = m_ShpReader.ReadDouble();
-                shape.Points.Add(new Vector3((float)x, 0, (float)y));
+                shape.Points.Add((x, 0, y));
             }
             return shape;
         }
@@ -157,7 +157,7 @@ namespace PlateauToolkit.Sandbox.Editor
 
     public interface IShape
     {
-        List<Vector3> Points { get; }
+        List<(double x, double y, double z)> Points { get; }
         List<int> Parts { get; }
         public string ToDataString()
         {
@@ -167,13 +167,13 @@ namespace PlateauToolkit.Sandbox.Editor
     }
     class PolylineShape : IShape
     {
-        public List<Vector3> Points { get; } = new List<Vector3>();
+        public List<(double x, double y, double z)> Points { get; } = new List<(double x, double y, double z)>();
         public List<int> Parts { get; set; } = new List<int>();
     }
 
     class PolygonShape : IShape
     {
-        public List<Vector3> Points { get; } = new List<Vector3>();
+        public List<(double x, double y, double z)> Points { get; } = new List<(double x, double y, double z)>();
         public List<int> Parts { get; set; } = new List<int>();
     }
 
@@ -181,10 +181,10 @@ namespace PlateauToolkit.Sandbox.Editor
     {
         // For a PointShape, we'll only ever have one point, but we're
         // implementing the IShape interface which requires a list.
-        public List<Vector3> Points { get; } = new List<Vector3>();
+        public List<(double x, double y, double z)> Points { get; } = new List<(double x, double y, double z)>();
         public List<int> Parts { get; } = new List<int>(); // Points do not have parts But we include this for interface compliance.
 
-        public PointShape(Vector3 point)
+        public PointShape((double, double, double) point)
         {
             Points.Add(point);
         }


### PR DESCRIPTION
## 関連リンク
<!-- libplateauのPR等、関連するPRがあれば書く。 -->
https://synesthesias.atlassian.net/browse/PLTSDK3-240
https://synesthesias.atlassian.net/browse/PLTSDK3-239

## 実装内容
・シェープファイル読み取り時に、緯度経度情報をfloatで丸めてしまっていたので、doubleでUnityの座標を取得するよう修正
・建物に配置されようとした時に、地面に配置するよう調整

## マージ前確認項目

## 動作確認（Win、Mac）

1. 京都市のモデルをimport
2. アセットのインポート 
3. 一括配置のタブよりShapefileを読み込み
4. アセットを選択
5. アセットを配置

<img width="738" alt="スクリーンショット 2024-09-24 9 30 45" src="https://github.com/user-attachments/assets/cde54e57-5656-421f-b8d6-a50e34148546">

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->