### PR TITLE
add:カメラターゲットをセットできるように

### DIFF
--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxCameraManager.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxCameraManager.cs
@@ -238,6 +238,10 @@ namespace PlateauToolkit.Sandbox
                 return;
             }
 
+            if (Camera.main == null)
+            {
+                return;
+            }
             m_LastMainCamera = Camera.main;
             m_LastMainCamera.enabled = false;
             m_SubCamera.enabled = true;

--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxCameraManager.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxCameraManager.cs
@@ -215,5 +215,34 @@ namespace PlateauToolkit.Sandbox
             m_CurrentCameraController = new(
                 m_CameraSettings, m_CameraPivot, cameraTarget, PlateauSandboxCameraMode.FirstPersonView);
         }
+
+        public void SetCameraTarget(Collider targetCollider)
+        {
+            if (targetCollider == null)
+            {
+                return;
+            }
+
+            if (!PlateauSandboxObjectFinder.TryGetSandboxObject(targetCollider, out IPlateauSandboxPlaceableObject sandboxObject))
+            {
+                return;
+            }
+
+            if (sandboxObject is not IPlateauSandboxCameraTarget cameraTarget)
+            {
+                return;
+            }
+
+            if (!cameraTarget.IsCameraViewAvailable)
+            {
+                return;
+            }
+
+            m_LastMainCamera = Camera.main;
+            m_LastMainCamera.enabled = false;
+            m_SubCamera.enabled = true;
+            m_CurrentCameraController = new(
+                m_CameraSettings, m_CameraPivot, cameraTarget, PlateauSandboxCameraMode.FirstPersonView);
+        }
     }
 }


### PR DESCRIPTION
## やったこと

- PlateauSandboxCameraManagerでマウスクリックではなく、オブジェクト指定で１人称視点に切り替えれるように対応