### PR TITLE
Fix/cpsdk25 82

### DIFF
--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
@@ -46,6 +46,8 @@ namespace PlateauToolkit.Sandbox.Editor
                             EditorSplineUtility.SetKnotPlacementTool();
                             RefreshTracksHierarchy(context);
                         };
+
+                        GUIUtility.ExitGUI();
                     }
                 }
                 else

--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxHuman.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxHuman.cs
@@ -41,7 +41,7 @@ namespace PlateauToolkit.Sandbox
 
         public void OnMove(in MovementInfo movementInfo, PlateauSandboxTrack track)
         {
-            (Vector3 position, Vector3 forward) = track.GetPositionAndForwardBySplineContainerT(movementInfo.m_SplineContainerT);
+            (Vector3 position, Vector3 forward) = track.GetPositionAndForwardBySplineContainerT(movementInfo.m_SplineContainerT, movementInfo.m_PositionOffset);
             m_Speed = movementInfo.m_MoveDelta / Time.deltaTime;
 
             Quaternion toRotation = Quaternion.LookRotation(forward, Vector3.up);

--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxTrack.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxTrack.cs
@@ -274,19 +274,30 @@ namespace PlateauToolkit.Sandbox
 
         public Vector3 GetPositionBySplineContainerT(float splineContainerT)
         {
+            return GetPositionBySplineContainerT(splineContainerT, Vector3.zero);
+        }
+
+        public Vector3 GetPositionBySplineContainerT(float splineContainerT, Vector3 positionOffset)
+        {
             (int splineIndex, float t) = GetSplineIndex(splineContainerT);
 
             Spline spline = SplineContainer[splineIndex];
-            return transform.TransformPoint(spline.EvaluatePosition(t));
+            return transform.TransformPoint(spline.EvaluatePosition(t)) + positionOffset;
         }
 
+
         public (Vector3, Vector3) GetPositionAndForwardBySplineContainerT(float splineContainerT)
+        {
+            return GetPositionAndForwardBySplineContainerT(splineContainerT, Vector3.zero);
+        }
+
+        public (Vector3, Vector3) GetPositionAndForwardBySplineContainerT(float splineContainerT, Vector3 positionOffset)
         {
             (int splineIndex, float t) = GetSplineIndex(splineContainerT);
 
             Spline spline = SplineContainer[splineIndex];
             return (
-                transform.TransformPoint(spline.EvaluatePosition(t)),
+                transform.TransformPoint(spline.EvaluatePosition(t)) + positionOffset,
                 transform.TransformDirection(spline.EvaluateTangent(t)).normalized);
         }
 

--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxTrackMovement.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxTrackMovement.cs
@@ -44,6 +44,7 @@ namespace PlateauToolkit.Sandbox
         public float m_Velocity;
         public float m_MoveDelta;
         public float m_SplineContainerT;
+        public Vector3 m_PositionOffset;
         public Vector3 m_LookaheadForward;
         public Vector3 m_SecondAxisPoint;
         public Vector3 m_SecondAxisForward;
@@ -189,15 +190,21 @@ namespace PlateauToolkit.Sandbox
                 return;
             }
 
-            (Vector3 position, Vector3 forward) = m_Track.GetPositionAndForwardBySplineContainerT(m_SplineContainerT);
-
             // Apply the offset.
-            position += transform.right * m_TrackOffset.x;
-            position += transform.up * m_TrackOffset.y;
-            position += transform.forward * m_TrackOffset.z;
+            Vector3 trackOffset = CalcTrackOffset(transform, m_TrackOffset);
+            (Vector3 position, Vector3 forward) = m_Track.GetPositionAndForwardBySplineContainerT(m_SplineContainerT, trackOffset);
 
             m_MovingObject.SetPosition(position);
             transform.rotation = Quaternion.LookRotation(forward, Vector3.up);
+        }
+
+        internal static Vector3 CalcTrackOffset(Transform transform, Vector3 trackOffset)
+        {
+            Vector3 position = Vector3.zero;
+            position += transform.right * trackOffset.x;
+            position += transform.up * trackOffset.y;
+            position += transform.forward * trackOffset.z;
+            return position;
         }
 
         public bool TrySetSplineContainerT(float t)
@@ -329,9 +336,12 @@ namespace PlateauToolkit.Sandbox
                 }
 
                 m_SplineContainerT = t;
+                Vector3 positionOffset = CalcTrackOffset(transform, m_TrackOffset);
 
                 MovementInfo movementInfo;
                 movementInfo.m_SplineContainerT = t;
+                movementInfo.m_PositionOffset = positionOffset;
+
 
                 float secondAxisDistance = m_MovingObject.SecondAxisDistance;
                 if (secondAxisDistance > 0)
@@ -339,7 +349,7 @@ namespace PlateauToolkit.Sandbox
                     randomWalkPathIterator.Clone()
                         .MoveByLinearDistance(secondAxisDistance, out float secondAxisT);
                     (movementInfo.m_SecondAxisPoint, movementInfo.m_SecondAxisForward) =
-                        m_Track.GetPositionAndForwardBySplineContainerT(secondAxisT);
+                        m_Track.GetPositionAndForwardBySplineContainerT(secondAxisT, positionOffset);
                 }
                 else
                 {
@@ -350,7 +360,7 @@ namespace PlateauToolkit.Sandbox
                 // Get an interpolation value of the collision detection point.
                 randomWalkPathIterator.Clone()
                     .MovePoint(Mathf.Max(m_CurrentVelocity, m_MinCollisionDetectDistance), out float collisionT);
-                Vector3 collisionPoint = m_Track.GetPositionBySplineContainerT(collisionT);
+                Vector3 collisionPoint = m_Track.GetPositionBySplineContainerT(collisionT, positionOffset);
 
                 m_CollisionPoint = collisionPoint + m_MovingObject.TransformUp * m_CollisionDetectHeight;
 

--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxVehicle.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxVehicle.cs
@@ -84,7 +84,7 @@ namespace PlateauToolkit.Sandbox
         public void OnMove(in MovementInfo movementInfo, PlateauSandboxTrack track)
         {
             // Align the object to the spline.
-            Vector3 position = track.GetPositionBySplineContainerT(movementInfo.m_SplineContainerT);
+            Vector3 position = track.GetPositionBySplineContainerT(movementInfo.m_SplineContainerT, movementInfo.m_PositionOffset);
 
             // Set the position first.
             SetPosition(position);


### PR DESCRIPTION
https://synesthesias.atlassian.net/browse/CPSDK25-82

今回修正したのは
1．手動トラック配置時に以下のエラーが表示される
> EndLayoutGroup: BeginLayoutGroup must be called first.
> UnityEngine.GUIUtility:ProcessEvent (int,intptr,bool&)

こちらは、ボタン押したときにGUIUtility>ExitGUI()を呼ぶようにしただけ

6. オフセット値が反映されない
> トラック上に人モデルを配置して歩かせる際にオフセット値が反映されていないようです。人モデルの配置時、インスペクターの更新時、移動処理のリセット（ループ）時には適用されています。PlateauSandboxTrackMovementコンポーネントのTrackOffsetが該当するフィールドです。
これは、こっちのプルリクを取り込んだので確認済み
https://github.com/Synesthesias/PLATEAU-SDK-Toolkits-for-Unity/pull/62
