### PR TITLE
Fix/cpsdk25 82 2

### DIFF
--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxContext.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxContext.cs
@@ -17,7 +17,7 @@ namespace PlateauToolkit.Sandbox.Editor
 
         //複数選択
         List<GameObject> m_SelectedObjects;
-        public List<GameObject> SelectedObjectsMultiple { get =>  m_SelectedObjects; }
+        public List<GameObject> SelectedObjectsMultiple { get => m_SelectedObjects; }
 
         public UnityEvent<GameObject> OnSelectedObjectChanged { get; } = new UnityEvent<GameObject>();
 
@@ -26,16 +26,29 @@ namespace PlateauToolkit.Sandbox.Editor
             get
             {
                 // TODO: Managing lifecycles of objects is the best way.
-                foreach (PlateauSandboxTrack track in m_Tracks)
+                if (IsAnyTrackDestroyed)
                 {
-                    if (track == null)
-                    {
-                        RefreshArrays(m_Tracks);
-                        break;
-                    }
+                    RefreshArrays(m_Tracks);
                 }
 
                 return m_Tracks;
+            }
+        }
+
+        /// <summary>
+        /// m_Tracksの中に破棄されたものがあるかどうかを返す
+        /// </summary>
+        public bool IsAnyTrackDestroyed
+        {
+            get
+            {
+                foreach (PlateauSandboxTrack track in m_Tracks)
+                {
+                    if (track == null)
+                        return true;
+                }
+
+                return false;
             }
         }
 

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxContext.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxContext.cs
@@ -11,7 +11,8 @@ namespace PlateauToolkit.Sandbox.Editor
     {
         static PlateauSandboxContext s_Current;
 
-        readonly List<PlateauSandboxTrack> m_Tracks = new();
+        // 最初にアクセスするまで生成を遅延する(後方互換の為)
+        List<PlateauSandboxTrack> m_Tracks = null;
         readonly PlacementSettings m_PlacementSettings = new();
         GameObject m_SelectedObject;
 
@@ -26,9 +27,9 @@ namespace PlateauToolkit.Sandbox.Editor
             get
             {
                 // TODO: Managing lifecycles of objects is the best way.
-                if (IsAnyTrackDestroyed)
+                if (m_Tracks == null || IsAnyTrackDestroyed)
                 {
-                    RefreshArrays(m_Tracks);
+                    RefreshArrays(ref m_Tracks);
                 }
 
                 return m_Tracks;
@@ -42,6 +43,9 @@ namespace PlateauToolkit.Sandbox.Editor
         {
             get
             {
+                if (m_Tracks == null)
+                    return false;
+
                 foreach (PlateauSandboxTrack track in m_Tracks)
                 {
                     if (track == null)
@@ -54,8 +58,9 @@ namespace PlateauToolkit.Sandbox.Editor
 
         public PlacementSettings PlacementSettings => m_PlacementSettings;
 
-        static void RefreshArrays<T>(List<T> list) where T : Component
+        static void RefreshArrays<T>(ref List<T> list) where T : Component
         {
+            list ??= new();
             list.Clear();
 
             Scene activeScene = SceneManager.GetActiveScene();
@@ -168,7 +173,7 @@ namespace PlateauToolkit.Sandbox.Editor
 
         public void RefreshTracks()
         {
-            RefreshArrays(m_Tracks);
+            RefreshArrays(ref m_Tracks);
         }
     }
 

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
@@ -43,9 +43,11 @@ namespace PlateauToolkit.Sandbox.Editor
             {
                 if (SelectedTrack && SelectedTrack.GetKnotsCount() == 0)
                 {
+                    // ↓でSelectedTrack初期化しているので一時変数に入れる
+                    var tmp = SelectedTrack;
                     EditorApplication.delayCall += () =>
                     {
-                        GameObject.DestroyImmediate(SelectedTrack.gameObject);
+                        GameObject.DestroyImmediate(tmp.gameObject);
                     };
                 }
                 ToolManager.activeToolChanged -= OnActiveToolChanged;

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
@@ -56,7 +56,7 @@ namespace PlateauToolkit.Sandbox.Editor
                             EditorSplineUtility.SetKnotPlacementTool();
                             RefreshTracksHierarchy(context);
                         };
-
+                        // EndLayoutGroup: BeginLayoutGroup must be called first.が出ないようにする対策
                         GUIUtility.ExitGUI();
                     }
                 }

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
@@ -46,6 +46,8 @@ namespace PlateauToolkit.Sandbox.Editor
                             EditorSplineUtility.SetKnotPlacementTool();
                             RefreshTracksHierarchy(context);
                         };
+
+                        GUIUtility.ExitGUI();
                     }
                 }
                 else

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
@@ -24,6 +24,16 @@ namespace PlateauToolkit.Sandbox.Editor
         public void OnGUI(PlateauSandboxContext context, EditorWindow window)
         {
             PlateauToolkitEditorGUILayout.Header("ツール");
+
+            // ヒエラルキーで直接破壊したとき用.
+            // Trackが外部から破壊されたときには表示を更新する
+            if (context.IsAnyTrackDestroyed)
+            {
+                EditorApplication.delayCall += () =>
+                {
+                    RefreshTracksHierarchy(context);
+                };
+            }
             using (new EditorGUILayout.VerticalScope())
             {
                 if (ToolManager.activeToolType.Name != "KnotPlacementTool")
@@ -88,6 +98,7 @@ namespace PlateauToolkit.Sandbox.Editor
                     }
                 }
             }
+
             EditorGUILayout.Space(15);
 
             m_TreeView.OnGUI(EditorGUILayout.GetControlRect(false, 200));
@@ -152,7 +163,6 @@ namespace PlateauToolkit.Sandbox.Editor
                             },
                         })),
             };
-
             var headerState = new MultiColumnHeaderState(m_HierarchyContext.Hierarchy.Header.Columns);
             var header = new MultiColumnHeader(headerState);
 

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
@@ -1,4 +1,5 @@
 ﻿using PlateauToolkit.Editor;
+using System;
 using System.Linq;
 using UnityEditor;
 using UnityEditor.EditorTools;
@@ -20,6 +21,51 @@ namespace PlateauToolkit.Sandbox.Editor
         {
             RefreshTracksHierarchy(context);
         }
+
+        /// <summary>
+        /// KnotPlacementToolの終了判定用
+        /// </summary>
+        private Type LastToolType { get; set; }
+
+        /// <summary>
+        /// 新規トラック作成で作成されたトラック
+        /// </summary>
+        private PlateauSandboxTrack SelectedTrack { get; set; }
+
+        /// <summary>
+        /// ToolManager.activeToolType切り替えコールバック
+        /// </summary>
+        void OnActiveToolChanged()
+        {
+            // KnotPlacementToolがinternalクラスでアクセスできないので名前ハードコーディング
+            // KnotPlacementToolが終わった時に, 対象のTrackにknotsが無ければキャンセル扱いで破棄する
+            if (LastToolType.Name == "KnotPlacementTool")
+            {
+                if (SelectedTrack && SelectedTrack.GetKnotsCount() == 0)
+                {
+                    EditorApplication.delayCall += () =>
+                    {
+                        GameObject.DestroyImmediate(SelectedTrack.gameObject);
+                    };
+                }
+                ToolManager.activeToolChanged -= OnActiveToolChanged;
+                SelectedTrack = null;
+            }
+
+            LastToolType = ToolManager.activeToolType;
+        }
+
+        /// <summary>
+        /// ToolManagerのactiveToolTypeの切り替え検知開始
+        /// </summary>
+        /// <param name="selectedTrack"></param>
+        void StartToolChangeNotifier(PlateauSandboxTrack selectedTrack)
+        {
+            SelectedTrack = selectedTrack;
+            LastToolType = ToolManager.activeToolType;
+            ToolManager.activeToolChanged += OnActiveToolChanged;
+        }
+
 
         public void OnGUI(PlateauSandboxContext context, EditorWindow window)
         {
@@ -45,10 +91,10 @@ namespace PlateauToolkit.Sandbox.Editor
                     {
                         string gameObjectName = GameObjectUtility.GetUniqueNameForSibling(null, "Track");
                         GameObject trackGameObject = ObjectFactory.CreateGameObject(gameObjectName, typeof(PlateauSandboxTrack));
-
                         trackGameObject.transform.localPosition = Vector3.zero;
                         trackGameObject.transform.localRotation = Quaternion.identity;
 
+                        StartToolChangeNotifier(trackGameObject.GetComponent<PlateauSandboxTrack>());
                         Selection.activeObject = trackGameObject;
                         ActiveEditorTracker.sharedTracker.RebuildIfNecessary();
                         EditorApplication.delayCall += () =>
@@ -56,6 +102,7 @@ namespace PlateauToolkit.Sandbox.Editor
                             EditorSplineUtility.SetKnotPlacementTool();
                             RefreshTracksHierarchy(context);
                         };
+
                         // EndLayoutGroup: BeginLayoutGroup must be called first.が出ないようにする対策
                         GUIUtility.ExitGUI();
                     }
@@ -70,6 +117,15 @@ namespace PlateauToolkit.Sandbox.Editor
                                 PlateauToolkitGUIStyles.k_ButtonCancelColor).Button("ESCキーまたはエンターキーでトラック作成を終了"))
                         {
                         }
+                    }
+
+                    var evt = Event.current;
+                    if (evt.type == EventType.KeyDown && evt.keyCode == KeyCode.Escape)
+                    {
+                        EditorApplication.delayCall += () =>
+                        {
+                        };
+                        GUIUtility.ExitGUI();
                     }
                 }
                 EditorGUILayout.Space(10);

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
@@ -120,15 +120,6 @@ namespace PlateauToolkit.Sandbox.Editor
                         {
                         }
                     }
-
-                    var evt = Event.current;
-                    if (evt.type == EventType.KeyDown && evt.keyCode == KeyCode.Escape)
-                    {
-                        EditorApplication.delayCall += () =>
-                        {
-                        };
-                        GUIUtility.ExitGUI();
-                    }
                 }
                 EditorGUILayout.Space(10);
 


### PR DESCRIPTION
# 概要
https://synesthesias.atlassian.net/browse/CPSDK25-82
の3, 4, 5 対応

## ス3. プラインのノーツを配置しなくても空のTrackがシーンに残る対応
コードの変更は以下のコミット
https://github.com/Project-PLATEAU/PLATEAU-SDK-Toolkits-for-Unity/commit/63a204b2796a0a00c7ddf24f961975a94614c316
https://github.com/Project-PLATEAU/PLATEAU-SDK-Toolkits-for-Unity/commit/f9c99fc03e2ccbdb11ba431220ff6278e23dc437

###確認方法
ツールバーのPLATEAU -> PLATEAU ToolKit -> Sandbox Toolkitでツールキットメニューを開く
トラック -> 手動トラック配置で手動トラック機能を起動
  -> ヒエラルキーにTrack(XX)という新しいトラックのゲームオブジェクトが配置されることを確認
シーンに移動し、何も配置しないままESCで終了する
  -> ↑で見つかったTrack(XX)のゲームオブジェクトが破壊されることを確認
![image](https://github.com/user-attachments/assets/15d8e676-a4bb-48dd-8426-b147c4bb6571)
![image](https://github.com/user-attachments/assets/707e0526-0c97-4610-ae4b-8ca0042d7c2d)

## 4. Sandbox Toolkit内のTrack表示が更新されない。
https://github.com/Project-PLATEAU/PLATEAU-SDK-Toolkits-for-Unity/commit/60971b9f886a36d888e9bda184c178c7b60a83a1
### 確認方法
> Sandbox Toolkitで生成したTrackが見えるようにする→ヒエラルキーで作成したTrackを削除
下図のリストのトラックから削除されたトラックが消えることを確認
![image](https://github.com/user-attachments/assets/d71806c9-28e9-416f-b83c-f73d5163be1f)

## 5.トラックが作成されている状態で配置ツールのトラックに配置を行うとトラックが見つからない。
トラックを作成されている状態にする→プロジェクトを開きなおす→Sandbox Toolkitの配置ツールを起動→シーンビューから配置位置をトラックに沿って配置に変更
### 確認方法
トラックを作成されている状態にする→プロジェクトを開きなおす→Sandbox Toolkitの配置ツールを起動→シーンビューから配置位置をトラックに沿って配置に変更
「トラックが見つからない」といったエラーが出ないことを確認








