### PR TITLE
Landscape-Design-Tool-3のアセット配置機能の改修用の機能追加

### DIFF
--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxAdvertisementScaled.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxAdvertisementScaled.cs
@@ -27,7 +27,7 @@ namespace PlateauToolkit.Sandbox.Runtime
             }
             set
             {
-                Vector3 v =  new Vector3(value.x / transform.lossyScale.x, value.y / transform.lossyScale.y, value.z / transform.lossyScale.z);
+                Vector3 v = new Vector3(value.x / transform.lossyScale.x, value.y / transform.lossyScale.y, value.z / transform.lossyScale.z);
                 billboardRoot.transform.localScale = v;
             }
         }
@@ -43,7 +43,7 @@ namespace PlateauToolkit.Sandbox.Runtime
             }
             set
             {
-                float y = value / transform.parent.lossyScale.y;
+                float y = value / transform.lossyScale.y;
                 poleRoot.transform.localScale = new Vector3(poleRoot.transform.localScale.x, y, poleRoot.transform.localScale.z);
 
                 // 高さの値に応じてbillboardRootのy座標を変更する

--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxAdvertisementScaled.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxAdvertisementScaled.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
+using UnityEngine.Video;
 
 namespace PlateauToolkit.Sandbox.Runtime
 {
@@ -15,6 +18,16 @@ namespace PlateauToolkit.Sandbox.Runtime
 
         //private Vector3 billboardDefaultPosition;
         //private Vector3 poleDefaultPosition;
+
+
+        // 画像と動画表示用
+        public int targetMaterialNumber;
+        public string targetTextureProperty = "_MainTex";
+        public PlateauSandboxAdvertisement.AdvertisementType advertisementType;
+        public List<PlateauSandboxAdvertisement.AdvertisementMaterials> advertisementMaterials;
+        public Texture advertisementTexture;
+        public VideoClip advertisementVideoClip;
+        public VideoPlayer VideoPlayer { get; private set; }
 
         /// <summary>
         /// ワールド空間でのサイズ
@@ -67,11 +80,79 @@ namespace PlateauToolkit.Sandbox.Runtime
             billboardRoot.transform.hasChanged = false;
         }
 
-        private void Awake()
+        public void AddVideoPlayer()
         {
-            //billboardDefaultPosition = billboardRoot.transform.position;
-            //poleDefaultPosition = poleRoot.transform.position;
+            if (!gameObject.TryGetComponent(out VideoPlayer videoPlayer))
+            {
+                videoPlayer = gameObject.AddComponent<VideoPlayer>();
+                videoPlayer.isLooping = true;
+                videoPlayer.renderMode = VideoRenderMode.RenderTexture;
+                videoPlayer.clip = advertisementVideoClip;
+                VideoPlayer = videoPlayer;
+            }
+            else
+            {
+                VideoPlayer = videoPlayer;
+            }
         }
+
+        public void SetTexture()
+        {
+            if (advertisementMaterials.Count <= 0)
+            {
+                return;
+            }
+
+            Material mat = advertisementMaterials[0].materials[targetMaterialNumber];
+            if (mat.HasProperty(targetTextureProperty))
+            {
+                // RenderTextureは設定しない
+                Texture texture = mat.GetTexture(targetTextureProperty);
+                if (texture as RenderTexture == null)
+                {
+                    advertisementTexture = texture;
+                }
+            }
+        }
+
+        public void SetMaterials()
+        {
+            MeshRenderer[] lsChildMeshRender = transform.GetComponentsInChildren<MeshRenderer>();
+            foreach (MeshRenderer childMeshRender in lsChildMeshRender)
+            {
+                IEnumerable<PlateauSandboxAdvertisement.AdvertisementMaterials> matchingMaterials =
+                    advertisementMaterials.Where(m => m.gameObjectName == childMeshRender.transform.name);
+
+                foreach (PlateauSandboxAdvertisement.AdvertisementMaterials advertisementMaterial in matchingMaterials)
+                {
+                    childMeshRender.sharedMaterials = advertisementMaterial.materials.ToArray();
+                }
+            }
+        }
+
+        public void Reset()
+        {
+            advertisementMaterials = new List<PlateauSandboxAdvertisement.AdvertisementMaterials>();
+            MeshRenderer[] lsChildMeshRender = transform.GetComponentsInChildren<MeshRenderer>();
+            foreach (MeshRenderer childMeshRender in lsChildMeshRender)
+            {
+                var advertisementMaterial = new PlateauSandboxAdvertisement.AdvertisementMaterials
+                {
+                    gameObjectName = childMeshRender.transform.name,
+                    materials = new List<Material>(childMeshRender.sharedMaterials)
+                };
+                advertisementMaterials.Add(advertisementMaterial);
+            }
+
+            SetTexture();
+            AddVideoPlayer();
+        }
+
+        // private void Awake()
+        // {
+        //     //billboardDefaultPosition = billboardRoot.transform.position;
+        //     //poleDefaultPosition = poleRoot.transform.position;
+        // }
 
     }
 }

--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Editor/PlateauSandboxBuildingEditor.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Editor/PlateauSandboxBuildingEditor.cs
@@ -66,11 +66,13 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
         private SerializedProperty m_ComplexBuildingVertexColorMaterialPalette;
         private SerializedProperty m_ComplexBuildingMaterialPalette;
 
+        private SerializedProperty m_IsSizePanelVisible;
+
         private GUIStyle m_SaveMeshBtnTextColorStyle;
 
         private void OnEnable()
         {
-            m_Generator = (Runtime.PlateauSandboxBuilding) target;
+            m_Generator = (Runtime.PlateauSandboxBuilding)target;
             m_UndoObjectWithShaderParam = new List<Object>();
 
             var lsLodObject = m_Generator.gameObject.GetComponentsInChildrenWithoutSelf<Transform>().ToList();
@@ -128,6 +130,8 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
             m_ComplexBuildingVertexColorMaterialPalette = serializedObject.FindProperty("complexBuildingVertexColorMaterialPalette");
             m_ComplexBuildingMaterialPalette = serializedObject.FindProperty("complexBuildingMaterialPalette");
 
+            m_IsSizePanelVisible = serializedObject.FindProperty("isSizePanelVisible");
+
             m_SaveMeshBtnTextColorStyle = null;
 
             Undo.undoRedoPerformed += OnUndo;
@@ -150,7 +154,7 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
             }
 
             // Supported LOD: LOD0
-            foreach (int lodNum in new List<int> {0})
+            foreach (int lodNum in new List<int> { 0 })
             {
                 if (m_Generator != null)
                 {
@@ -307,7 +311,7 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
                             {
                                 {"textureOffsetX", new Tuple<string, float, float>("横のオフセット値", -1f, 1f)},
                                 {"textureOffsetY", new Tuple<string, float, float>("縦のオフセット値", -1f, 1f)},
-                            }, isUpdateShaderParams:true))
+                            }, isUpdateShaderParams: true))
                         {
                             SerializedProperty roofSideFrontSerializedProperty = m_HotelMaterialPalette.FindPropertyRelative("roofSideFront");
                             if (roofSideFrontSerializedProperty != null)
@@ -349,7 +353,7 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
                                 {
                                     {"textureOffsetX", new Tuple<string, float, float>("横のオフセット値", -1f, 1f)},
                                     {"textureOffsetY", new Tuple<string, float, float>("縦のオフセット値", -1f, 1f)}
-                                }, isUpdateShaderParams:true))
+                                }, isUpdateShaderParams: true))
                             {
                                 SerializedProperty roofSideFrontSerializedProperty = m_ComplexBuildingMaterialPalette.FindPropertyRelative("hotelRoofSideFront");
                                 if (roofSideFrontSerializedProperty != null)
@@ -432,7 +436,7 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
                 EditorUtility.SetDirty(m_Generator);
 
                 // Supported LOD: LOD0
-                foreach (int lodNum in new List<int> {0})
+                foreach (int lodNum in new List<int> { 0 })
                 {
                     m_Generator.GenerateMesh(lodNum, m_Generator.buildingWidth, m_Generator.buildingDepth);
                 }
@@ -491,6 +495,21 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
             if (changedValue)
             {
                 EditorUtility.SetDirty(m_Generator);
+            }
+
+            EditorGUILayout.Space(5);
+            GuiUtility.Separator(m_SeparatorColor);
+            EditorGUILayout.Space(5);
+
+            EditorGUI.BeginChangeCheck();
+            bool newShowSizePanel = EditorGUILayout.ToggleLeft(
+                new GUIContent("サイズ変更パネル表示", "サイズ調整用 UI の表示/非表示"),
+                m_IsSizePanelVisible.boolValue);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                m_IsSizePanelVisible.boolValue = newShowSizePanel;
+                serializedObject.ApplyModifiedProperties();
             }
         }
 
@@ -673,7 +692,7 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Editor
                         changedComplexHotelBuildingParam = DrawDynamicPropertyOnly(m_ComplexHotelParams, new Dictionary<string, Tuple<string, float, float>>
                         {
                             {"roofThickness", new Tuple<string, float, float>("屋根の厚さ", 0f, 5f)}
-                        }, hideParam:higherFloorBuildingTypeProperty.enumValueIndex != (int)ComplexBuildingConfig.ComplexBuildingType.k_Hotel);
+                        }, hideParam: higherFloorBuildingTypeProperty.enumValueIndex != (int)ComplexBuildingConfig.ComplexBuildingType.k_Hotel);
                     }
 
                     return changedComplexBuildingParam || changedComplexSkyscraperCondominiumBuildingParam || changedComplexOfficeBuildingParam || changedComplexHotelBuildingParam || changedComplexHotelShaderBuildingParam;

--- a/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Runtime/PlateauSandboxBuilding.cs
+++ b/PlateauToolkit.Sandbox/Runtime/PlateauSandboxBuildings/Runtime/PlateauSandboxBuilding.cs
@@ -82,6 +82,8 @@ namespace PlateauToolkit.Sandbox.Runtime.PlateauSandboxBuildings.Runtime
         public RoofPlanner roofPlanner;
         public RoofConstructor roofConstructor;
 
+        public bool isSizePanelVisible = false;
+
         public string GetBuildingName()
         {
             return buildingType switch


### PR DESCRIPTION
## 概要
- ギズモによるスケール変更があった場合に広告のサイズがおかしくなる不具合を修正
- PlateauSandboxAdvertisementScaledに動画再生、画像表示機能を追加
- サイズ変更パネル表示非表示用のプロパティを追加

Landscape-Design-Tool-3のdev_featuresと一緒にマージをお願いします。