### PR TITLE
Tile対応

### DIFF
--- a/PlateauToolkit.Rendering/Editor/Grouping.cs
+++ b/PlateauToolkit.Rendering/Editor/Grouping.cs
@@ -126,6 +126,71 @@ namespace PlateauToolkit.Rendering.Editor
             OnProcessingFinished?.Invoke();
         }
 
+        /// <summary>
+        /// Root Transform内のオブジェクトを地物ごとにグルーピングします。
+        /// </summary>
+        /// <param name="transformRoot"></param>
+        internal void GroupObjectsInTransform(Transform transformRoot)
+        {
+            Dictionary<string, GameObject> rootObjects = new Dictionary<string, GameObject>();
+            Dictionary<string, Dictionary<string, GameObject>> lodObjects = new Dictionary<string, Dictionary<string, GameObject>>();
+
+            List<Transform> copyOfGroupedBuildingsList = new List<Transform>();
+            List<GameObject> objectsToDelete = new List<GameObject>();
+
+            for (int i = 0; i < transformRoot.childCount; i++)
+            {
+                Transform gmlRoot = transformRoot.GetChild(i);
+                float stepProgress = i / (float)transformRoot.childCount;
+                if (EditorUtility.DisplayCancelableProgressBar("地物のグルーピング", "グルーピング中", stepProgress))
+                {
+                    UnityEngine.Debug.Log("LOD生成用のグルーピングがキャンセルされました。");
+                    break;
+                }
+
+                objectsToDelete.Clear();
+                for (int k = 0; k < gmlRoot.childCount; k++)
+                {
+                    Transform lodGroupedBuildings = gmlRoot.transform.GetChild(k);
+                    if (lodGroupedBuildings.name.Contains("LOD0") || lodGroupedBuildings.name.Contains("LOD1") || lodGroupedBuildings.name.Contains("LOD2"))
+                    {
+                        copyOfGroupedBuildingsList.Clear();
+                        for (int l = 0; l < lodGroupedBuildings.transform.childCount; l++)
+                        {
+                            Transform building = lodGroupedBuildings.transform.GetChild(l);
+                            copyOfGroupedBuildingsList.Add(building);
+                        }
+
+                        for (int m = 0; m < copyOfGroupedBuildingsList.Count; m++)
+                        {
+                            Transform buildingCopy = copyOfGroupedBuildingsList[m];
+                            GroupByLodName(gmlRoot, rootObjects, lodObjects, buildingCopy.gameObject, lodGroupedBuildings.name);
+                        }
+                    }
+
+                    if (lodGroupedBuildings.childCount == 0 && !PrefabUtility.IsPartOfAnyPrefab(lodGroupedBuildings.gameObject))
+                    {
+                        objectsToDelete.Add(lodGroupedBuildings.gameObject);
+                    }
+                }
+
+                foreach (GameObject obj in objectsToDelete)
+                {
+                    try
+                    {
+                        GameObject.DestroyImmediate(obj);
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogException(e);
+                        Debug.Log("object name: " + obj.name);
+                    }
+                }
+            }
+            EditorUtility.ClearProgressBar();
+            OnProcessingFinished?.Invoke();
+        }
+
         void GroupByLodName(Transform gmlRoot, Dictionary<string, GameObject> rootObjectDictionary, Dictionary<string, Dictionary<string, GameObject>> lodDictionary, GameObject obj, string lodLevel)
         {
             // Use the object name as the key for grouping but ignore if we find _plateau_auto_textured because user may have textured the Lod1 first before creating LOD group

--- a/PlateauToolkit.Rendering/Editor/Grouping.cs
+++ b/PlateauToolkit.Rendering/Editor/Grouping.cs
@@ -138,9 +138,9 @@ namespace PlateauToolkit.Rendering.Editor
             List<Transform> copyOfGroupedBuildingsList = new List<Transform>();
             List<GameObject> objectsToDelete = new List<GameObject>();
 
+            objectsToDelete.Clear();
             for (int i = 0; i < transformRoot.childCount; i++)
             {
-                Transform gmlRoot = transformRoot.GetChild(i);
                 float stepProgress = i / (float)transformRoot.childCount;
                 if (EditorUtility.DisplayCancelableProgressBar("地物のグルーピング", "グルーピング中", stepProgress))
                 {
@@ -148,43 +148,41 @@ namespace PlateauToolkit.Rendering.Editor
                     break;
                 }
 
-                objectsToDelete.Clear();
-                for (int k = 0; k < gmlRoot.childCount; k++)
+                Transform lodGroupedBuildings = transformRoot.transform.GetChild(i);
+                if (lodGroupedBuildings.name.Contains("LOD0") || lodGroupedBuildings.name.Contains("LOD1") || lodGroupedBuildings.name.Contains("LOD2"))
                 {
-                    Transform lodGroupedBuildings = gmlRoot.transform.GetChild(k);
-                    if (lodGroupedBuildings.name.Contains("LOD0") || lodGroupedBuildings.name.Contains("LOD1") || lodGroupedBuildings.name.Contains("LOD2"))
+                    copyOfGroupedBuildingsList.Clear();
+                    for (int l = 0; l < lodGroupedBuildings.transform.childCount; l++)
                     {
-                        copyOfGroupedBuildingsList.Clear();
-                        for (int l = 0; l < lodGroupedBuildings.transform.childCount; l++)
-                        {
-                            Transform building = lodGroupedBuildings.transform.GetChild(l);
-                            copyOfGroupedBuildingsList.Add(building);
-                        }
-
-                        for (int m = 0; m < copyOfGroupedBuildingsList.Count; m++)
-                        {
-                            Transform buildingCopy = copyOfGroupedBuildingsList[m];
-                            GroupByLodName(gmlRoot, rootObjects, lodObjects, buildingCopy.gameObject, lodGroupedBuildings.name);
-                        }
+                        Transform building = lodGroupedBuildings.transform.GetChild(l);
+                        copyOfGroupedBuildingsList.Add(building);
                     }
 
-                    if (lodGroupedBuildings.childCount == 0 && !PrefabUtility.IsPartOfAnyPrefab(lodGroupedBuildings.gameObject))
+                    for (int m = 0; m < copyOfGroupedBuildingsList.Count; m++)
                     {
-                        objectsToDelete.Add(lodGroupedBuildings.gameObject);
+                        Transform buildingCopy = copyOfGroupedBuildingsList[m];
+                        GroupByLodName(transformRoot, rootObjects, lodObjects, buildingCopy.gameObject, lodGroupedBuildings.name);
                     }
                 }
 
-                foreach (GameObject obj in objectsToDelete)
+                if (lodGroupedBuildings.childCount == 0 && !PrefabUtility.IsPartOfAnyPrefab(lodGroupedBuildings.gameObject))
                 {
-                    try
-                    {
-                        GameObject.DestroyImmediate(obj);
-                    }
-                    catch (Exception e)
-                    {
-                        Debug.LogException(e);
-                        Debug.Log("object name: " + obj.name);
-                    }
+                    objectsToDelete.Add(lodGroupedBuildings.gameObject);
+
+                    Debug.Log("Deleting empty LOD group: " + lodGroupedBuildings.name);
+                }
+            }
+
+            foreach (GameObject obj in objectsToDelete)
+            {
+                try
+                {
+                    GameObject.DestroyImmediate(obj);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                    Debug.Log("object name: " + obj.name);
                 }
             }
             EditorUtility.ClearProgressBar();

--- a/PlateauToolkit.Rendering/Editor/Grouping.cs
+++ b/PlateauToolkit.Rendering/Editor/Grouping.cs
@@ -86,26 +86,7 @@ namespace PlateauToolkit.Rendering.Editor
                     for (int k = 0; k < gmlRoot.childCount; k++)
                     {
                         Transform lodGroupedBuildings = gmlRoot.transform.GetChild(k);
-                        if (lodGroupedBuildings.name.Contains("LOD0") || lodGroupedBuildings.name.Contains("LOD1") || lodGroupedBuildings.name.Contains("LOD2"))
-                        {
-                            copyOfGroupedBuildingsList.Clear();
-                            for (int l = 0; l < lodGroupedBuildings.transform.childCount; l++)
-                            {
-                                Transform building = lodGroupedBuildings.transform.GetChild(l);
-                                copyOfGroupedBuildingsList.Add(building);
-                            }
-
-                            for (int m = 0; m < copyOfGroupedBuildingsList.Count; m++)
-                            {
-                                Transform buildingCopy = copyOfGroupedBuildingsList[m];
-                                GroupByLodName(gmlRoot, rootObjects, lodObjects, buildingCopy.gameObject, lodGroupedBuildings.name);
-                            }
-                        }
-
-                        if (lodGroupedBuildings.childCount == 0 && !PrefabUtility.IsPartOfAnyPrefab(lodGroupedBuildings.gameObject))
-                        {
-                            objectsToDelete.Add(lodGroupedBuildings.gameObject);
-                        }
+                        GroupObjectsInner(gmlRoot, lodGroupedBuildings, rootObjects, lodObjects, copyOfGroupedBuildingsList, objectsToDelete);
                     }
 
                     foreach (GameObject obj in objectsToDelete)
@@ -122,7 +103,7 @@ namespace PlateauToolkit.Rendering.Editor
                     }
                 }
             }
-            EditorUtility.ClearProgressBar();
+            EditorUtility.ClearProgressBar();  
             OnProcessingFinished?.Invoke();
         }
 
@@ -138,7 +119,6 @@ namespace PlateauToolkit.Rendering.Editor
             List<Transform> copyOfGroupedBuildingsList = new List<Transform>();
             List<GameObject> objectsToDelete = new List<GameObject>();
 
-            objectsToDelete.Clear();
             for (int i = 0; i < transformRoot.childCount; i++)
             {
                 float stepProgress = i / (float)transformRoot.childCount;
@@ -149,28 +129,7 @@ namespace PlateauToolkit.Rendering.Editor
                 }
 
                 Transform lodGroupedBuildings = transformRoot.transform.GetChild(i);
-                if (lodGroupedBuildings.name.Contains("LOD0") || lodGroupedBuildings.name.Contains("LOD1") || lodGroupedBuildings.name.Contains("LOD2"))
-                {
-                    copyOfGroupedBuildingsList.Clear();
-                    for (int l = 0; l < lodGroupedBuildings.transform.childCount; l++)
-                    {
-                        Transform building = lodGroupedBuildings.transform.GetChild(l);
-                        copyOfGroupedBuildingsList.Add(building);
-                    }
-
-                    for (int m = 0; m < copyOfGroupedBuildingsList.Count; m++)
-                    {
-                        Transform buildingCopy = copyOfGroupedBuildingsList[m];
-                        GroupByLodName(transformRoot, rootObjects, lodObjects, buildingCopy.gameObject, lodGroupedBuildings.name);
-                    }
-                }
-
-                if (lodGroupedBuildings.childCount == 0 && !PrefabUtility.IsPartOfAnyPrefab(lodGroupedBuildings.gameObject))
-                {
-                    objectsToDelete.Add(lodGroupedBuildings.gameObject);
-
-                    Debug.Log("Deleting empty LOD group: " + lodGroupedBuildings.name);
-                }
+                GroupObjectsInner(transformRoot, lodGroupedBuildings, rootObjects, lodObjects, copyOfGroupedBuildingsList, objectsToDelete);
             }
 
             foreach (GameObject obj in objectsToDelete)
@@ -187,6 +146,33 @@ namespace PlateauToolkit.Rendering.Editor
             }
             EditorUtility.ClearProgressBar();
             OnProcessingFinished?.Invoke();
+        }
+
+        void GroupObjectsInner(Transform transformRoot, Transform
+            lodGroupedBuildings, Dictionary<string, GameObject> rootObjects,
+            Dictionary<string, Dictionary<string, GameObject>> lodObjects,
+            List<Transform> copyOfGroupedBuildingsList, List<GameObject> objectsToDelete)
+        {
+            if (lodGroupedBuildings.name.Contains("LOD0") || lodGroupedBuildings.name.Contains("LOD1") || lodGroupedBuildings.name.Contains("LOD2"))
+            {
+                copyOfGroupedBuildingsList.Clear();
+                for (int l = 0; l < lodGroupedBuildings.transform.childCount; l++)
+                {
+                    Transform building = lodGroupedBuildings.transform.GetChild(l);
+                    copyOfGroupedBuildingsList.Add(building);
+                }
+
+                for (int m = 0; m < copyOfGroupedBuildingsList.Count; m++)
+                {
+                    Transform buildingCopy = copyOfGroupedBuildingsList[m];
+                    GroupByLodName(transformRoot, rootObjects, lodObjects, buildingCopy.gameObject, lodGroupedBuildings.name);
+                }
+            }
+
+            if (lodGroupedBuildings.childCount == 0 && !PrefabUtility.IsPartOfAnyPrefab(lodGroupedBuildings.gameObject))
+            {
+                objectsToDelete.Add(lodGroupedBuildings.gameObject);
+            }
         }
 
         void GroupByLodName(Transform gmlRoot, Dictionary<string, GameObject> rootObjectDictionary, Dictionary<string, Dictionary<string, GameObject>> lodDictionary, GameObject obj, string lodLevel)

--- a/PlateauToolkit.Rendering/Editor/PlateauRenderingBuildingUtilities.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauRenderingBuildingUtilities.cs
@@ -80,7 +80,8 @@ namespace PlateauToolkit.Rendering.Editor
         /// <returns></returns>
         public static bool IsPlateauBuilding(Transform transformOfSelectedMesh)
         {
-            return transformOfSelectedMesh.HasParentWithComponent<PLATEAUInstancedCityModel>() && (transformOfSelectedMesh.name.Contains("BLD") || transformOfSelectedMesh.name.Contains("bldg") || transformOfSelectedMesh.name.Contains("group"));
+            return (transformOfSelectedMesh.HasParentWithComponent<PLATEAUInstancedCityModel>() || transformOfSelectedMesh.HasParentWithComponent<PLATEAU.DynamicTile.PLATEAUTileManager>())
+                && (transformOfSelectedMesh.name.Contains("BLD") || transformOfSelectedMesh.name.Contains("bldg") || transformOfSelectedMesh.name.Contains("group"));
         }
 
         static bool HasParentWithComponent<T>(this Transform child) where T : Component

--- a/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
@@ -225,7 +225,8 @@ namespace PlateauToolkit.Rendering.Editor
                 foreach (Transform transform in tileTransforms)
                 {
                     List<GameObject> processsingGameObjects = GetChildGameObjects(transform);
-                    if (PlateauRenderingBuildingUtilities.GetMeshStructure(processsingGameObjects.First()) != PlateauMeshStructure.CombinedArea && !processsingGameObjects.First().name.Contains(PlateauRenderingConstants.k_Grouped))
+                    GameObject firstObject = processsingGameObjects.FirstOrDefault();
+                    if (firstObject != null && PlateauRenderingBuildingUtilities.GetMeshStructure(firstObject) != PlateauMeshStructure.CombinedArea && !firstObject.name.Contains(PlateauRenderingConstants.k_Grouped))
                     {
                         m_Grouping.GroupObjectsInTransform(transform);
                         processsingGameObjects.RemoveAll(go => go == null);

--- a/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
@@ -20,7 +20,7 @@ namespace PlateauToolkit.Rendering.Editor
     {
         SceneTileChooserType SelectedType { get; }
         void Draw();
-        void AutoTexture();
+        void CreateTexture();
     }
 
     public class PlateauToolkitRenderingTileStrategy : IPlateauToolkitRenderingStrategy
@@ -42,7 +42,7 @@ namespace PlateauToolkit.Rendering.Editor
 
         public bool IsTileManagerSelected => m_SceneTileChooser?.SelectedType == SceneTileChooserType.DynamicTile && m_TileListElementData != null && m_TileListElementData.TileManager != null;
 
-        internal PlateauToolkitRenderingTileStrategy(PlateauToolkitRenderingWindow editorWindow, AutoTexturing autoTextureProcessor, Grouping grouping)
+        internal PlateauToolkitRenderingTileStrategy(PlateauToolkitRenderingWindow editorWindow)
         {
             if (m_TileListElementData == null)
             {
@@ -61,8 +61,16 @@ namespace PlateauToolkit.Rendering.Editor
             }
 
             m_ParentWindow = editorWindow;
-            m_AutoTextureProcessor = autoTextureProcessor;
-            m_Grouping = grouping;
+            if (m_Grouping == null)
+            {
+                m_Grouping = new Grouping();
+            }
+
+            if (m_AutoTextureProcessor == null)
+            {
+                m_AutoTextureProcessor = new AutoTexturing();
+                m_AutoTextureProcessor.Initialize();
+            }
         }
 
         public void Draw()
@@ -92,72 +100,89 @@ namespace PlateauToolkit.Rendering.Editor
                 });
         }
 
-        public void AutoTexture()
+        public void CreateTexture()
         {
             AutoTextureAsync().ContinueWithErrorCatch();
         }
 
-        public async Task AutoTextureAsync()
+        async Task AutoTextureAsync()
         {
-            using (var cts = new CancellationTokenSource())
+            bool isOptionSelected = EditorUtility.DisplayDialog(
+                   "テクスチャ作成の確認",
+                   "テクスチャを生成します。必要に応じてHierarchy にある地物の構成が変更されることもあります。実行しますか？",
+                   "はい",
+                   "いいえ"
+               );
+
+            if (isOptionSelected)
             {
-                try
+                m_ParentWindow.BlockUI();
+
+                using (var cts = new CancellationTokenSource())
                 {
-                    CancellationToken ct = cts.Token;
-                    m_TileRebuilder = new TileRebuilder();
-                    PLATEAUTileManager tileManager = m_TileListElementData.TileManager;
-                    ObservableCollection<TileSelectionItem> selectedBuildingTiles = TileConvertCommon.FilterByPackage(PLATEAU.Dataset.PredefinedCityModelPackage.Building, m_TileListElementData.ObservableSelectedTiles, tileManager); // 建物地物に絞り込み
-
-                    List<PLATEAUDynamicTile> selectedTiles = TileConvertCommon.GetSelectedTiles(selectedBuildingTiles, tileManager);
-                    Transform editingTile = await TileConvertCommon.GetEditableTransformParent(selectedBuildingTiles, tileManager, m_TileRebuilder, ct);
-                    List<Transform> tileTransforms = TileConvertCommon.GetEditableTransforms(selectedBuildingTiles, editingTile);
-
-                    if (tileTransforms.Count > 0)
+                    try
                     {
-                        bool isOptionSelected = EditorUtility.DisplayDialog(
-                               "テクスチャ作成の確認",
-                               "テクスチャを生成します。必要に応じてHierarchy にある地物の構成が変更されることもあります。実行しますか？",
-                               "はい",
-                               "いいえ"
-                           );
-                        if (isOptionSelected)
+                        CancellationToken ct = cts.Token;
+                        m_TileRebuilder = new TileRebuilder();
+                        PLATEAUTileManager tileManager = m_TileListElementData.TileManager;
+                        ObservableCollection<TileSelectionItem> selectedBuildingTiles = TileConvertCommon.FilterByPackage(PLATEAU.Dataset.PredefinedCityModelPackage.Building, m_TileListElementData.ObservableSelectedTiles, tileManager); // 建物地物に絞り込み
+
+                        List<PLATEAUDynamicTile> selectedTiles = TileConvertCommon.GetSelectedTiles(selectedBuildingTiles, tileManager);
+                        Transform editingTile = await TileConvertCommon.GetEditableTransformParent(selectedBuildingTiles, tileManager, m_TileRebuilder, ct);
+                        List<Transform> tileTransforms = TileConvertCommon.GetEditableTransforms(selectedBuildingTiles, editingTile);
+
+                        if (tileTransforms.Count > 0)
                         {
-                            m_ParentWindow.BlockUI();
+
 #if PLATEAU_SDK_222
-                            // 主要地物に変換します。
-                            PLATEAU.CityImport.Import.Convert.GranularityConvertResult result = await new CityGranularityConverter().ConvertAsync(new GranularityConvertOptionUnity(new GranularityConvertOption(ConvertGranularity.PerPrimaryFeatureObject, 1), new UniqueParentTransformList(tileTransforms), true));
-                            tileTransforms = TileConvertCommon.GetEditableTransforms(selectedBuildingTiles, editingTile); // 変換後の Tile を再取得
+
+                            IEnumerable<Transform> convertibleTiles = tileTransforms.Where(t => Enumerable.Range(0, t.childCount)
+                              .Select(i => t.GetChild(i).name).All(n => n.StartsWith("LOD"))); // タイル直下の子が全てLODであるタイルのみ抽出 (改造構造が変わっていると変換できない）
+                            if (convertibleTiles.Any())
+                            {
+                                // 主要地物に変換します。
+                                PLATEAU.CityImport.Import.Convert.GranularityConvertResult result = await new CityGranularityConverter().ConvertAsync(
+                                    new GranularityConvertOptionUnity(
+                                        new GranularityConvertOption(ConvertGranularity.PerPrimaryFeatureObject, 1), new UniqueParentTransformList(convertibleTiles), true));
+                                tileTransforms = TileConvertCommon.GetEditableTransforms(selectedBuildingTiles, editingTile); // 変換後の Tile を再取得
+                            }
 #endif
-                            List<GameObject> processsingGameObjects = GetChildGameObjects(tileTransforms); // 変換後の主要地物オブジェクトをすべて取得
-                            if (PlateauRenderingBuildingUtilities.GetMeshStructure(processsingGameObjects[0]) != PlateauMeshStructure.CombinedArea && !processsingGameObjects[0].name.Contains(PlateauRenderingConstants.k_Grouped))
+                            foreach (Transform transform in tileTransforms)
                             {
-                                m_Grouping.GroupObjectsInTransform(editingTile);
-                            }
-                            var tcs = new TaskCompletionSource<bool>();
-                            void OnProcessingFinishedHandler()
-                            {
-                                // 処理完了時のコールバック
-                                m_ParentWindow.UnblockUI();
-                                m_AutoTextureProcessor.OnProcessingFinished -= OnProcessingFinishedHandler;
-                                tcs.TrySetResult(true);
-                            }
-                            m_AutoTextureProcessor.OnProcessingFinished += OnProcessingFinishedHandler;
+                                List<GameObject> processsingGameObjects = GetChildGameObjects(transform);
+                                if (PlateauRenderingBuildingUtilities.GetMeshStructure(processsingGameObjects.First()) != PlateauMeshStructure.CombinedArea && !processsingGameObjects.First().name.Contains(PlateauRenderingConstants.k_Grouped))
+                                {
+                                    m_Grouping.GroupObjectsInTransform(transform);
+                                    processsingGameObjects.RemoveAll(go => go == null);
+                                }
 
-                            m_AutoTextureProcessor.RunOptimizeProcess(processsingGameObjects); // 処理開始
+                                var tcs = new TaskCompletionSource<bool>();
+                                void OnProcessingFinishedHandler()
+                                {
+                                    // 処理完了時のコールバック
+                                    m_AutoTextureProcessor.OnProcessingFinished -= OnProcessingFinishedHandler;
+                                    tcs.TrySetResult(true);
+                                }
 
-                            await tcs.Task; // 完了待ち
+                                m_AutoTextureProcessor.OnProcessingFinished += OnProcessingFinishedHandler;
+                                m_AutoTextureProcessor.RunOptimizeProcess(processsingGameObjects); // 処理開始
+                                await tcs.Task; // 完了待ち
+                            }
                         }
-                    }
 
-                    //tileTransforms.Clear();
-                    //tileTransforms = TileConvertCommon.GetEditableTransforms(selectedBuildingTiles, editingTile, true); // Tileとして取得し直す
-                    await TileConvertCommon.SavePrefabAssets(tileTransforms, m_TileRebuilder, ct);
-                    await m_TileRebuilder.RebuildByTiles(tileManager, selectedTiles);
-                }
-                catch (Exception ex)
-                {
-                    Debug.LogException(ex);
-                    m_TileRebuilder?.CancelRebuild();
+                        tileTransforms = TileConvertCommon.GetEditableTransforms(selectedBuildingTiles, editingTile, true); // Tileとして取得し直す
+                        await TileConvertCommon.SavePrefabAssets(tileTransforms, m_TileRebuilder, ct);
+                        await m_TileRebuilder.RebuildByTiles(tileManager, selectedTiles);
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.LogException(ex);
+                        m_TileRebuilder?.CancelRebuild();
+                    }
+                    finally
+                    {
+                        m_ParentWindow.UnblockUI();
+                    }
                 }
             }
         }
@@ -167,16 +192,13 @@ namespace PlateauToolkit.Rendering.Editor
         /// </summary>
         /// <param name="tileTransform"></param>
         /// <returns></returns>
-        public List<GameObject> GetChildGameObjects(List<Transform> tileTransform)
+        public List<GameObject> GetChildGameObjects(Transform tileTransform)
         {
             var selectedGameObjects = new List<GameObject>();
-            foreach (Transform trans in tileTransform)
+            PLATEAUCityObjectGroup[] children = tileTransform.GetComponentsInChildren<PLATEAUCityObjectGroup>();
+            foreach (PLATEAUCityObjectGroup child in children)
             {
-                PLATEAUCityObjectGroup[] children = trans.GetComponentsInChildren<PLATEAUCityObjectGroup>();
-                foreach (PLATEAUCityObjectGroup child in children)
-                {
-                    selectedGameObjects.Add(child.gameObject);
-                }
+                selectedGameObjects.Add(child.gameObject);
             }
             return selectedGameObjects;
         }

--- a/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
@@ -1,0 +1,184 @@
+﻿using PLATEAU.CityInfo;
+using PLATEAU.DynamicTile;
+using PLATEAU.Editor.DynamicTile;
+using PLATEAU.Editor.Window.Common.Tile;
+using PLATEAU.GranularityConvert;
+using PLATEAU.Util;
+using PLATEAU.Util.Async;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace PlateauToolkit.Rendering.Editor
+{
+    public interface IPlateauToolkitRenderingStrategy
+    {
+        SceneTileChooserType SelectedType { get; }
+        void Draw();
+        void AutoTexture();
+    }
+
+    public class PlateauToolkitRenderingTileStrategy : IPlateauToolkitRenderingStrategy
+    {
+        PlateauToolkitRenderingWindow m_ParentWindow;
+
+        SceneTileChooserImgui m_SceneTileChooser;
+        TileListElement m_TileListElement;
+        TileListElementData m_TileListElementData;
+
+        TileRebuilder m_TileRebuilder;
+
+        // Auto texturing
+        AutoTexturing m_AutoTextureProcessor;
+        // LOD grouping
+        Grouping m_Grouping;
+
+        public SceneTileChooserType SelectedType => m_SceneTileChooser?.SelectedType ?? SceneTileChooserType.SceneObject;
+
+        public bool IsTileManagerSelected => m_SceneTileChooser?.SelectedType == SceneTileChooserType.DynamicTile && m_TileListElementData != null && m_TileListElementData.TileManager != null;
+
+        internal PlateauToolkitRenderingTileStrategy(PlateauToolkitRenderingWindow editorWindow, AutoTexturing autoTextureProcessor, Grouping grouping)
+        {
+            if (m_TileListElementData == null)
+            {
+                m_TileListElementData = new TileListElementData(editorWindow);
+                m_TileListElementData.EnableTileHierarchy = false; // 子要素選択不可
+            }
+
+            if (m_SceneTileChooser == null)
+            {
+                m_SceneTileChooser = new SceneTileChooserImgui();
+            }
+
+            if (m_TileListElement == null)
+            {
+                m_TileListElement = new TileListElement(m_TileListElementData);
+            }
+
+            m_ParentWindow = editorWindow;
+            m_AutoTextureProcessor = autoTextureProcessor;
+            m_Grouping = grouping;
+        }
+
+        public void Draw()
+        {
+            // タイル選択UIの表示
+            m_SceneTileChooser.DrawAndInvoke(
+                () => { }, // シーンタイル選択時の処理は不要
+                () =>
+                {
+                    // 動的タイルを選択した場合の処理
+                    if (m_TileListElementData.TileManager == null)
+                    {
+                        m_TileListElementData.TileManager = UnityEngine.Object.FindObjectOfType<PLATEAUTileManager>();
+                    }
+                    m_TileListElementData.TileManager =
+                        (PLATEAUTileManager)EditorGUILayout.ObjectField(
+                            "調整対象", m_TileListElementData.TileManager,
+                            typeof(PLATEAUTileManager), true);
+                    if (m_TileListElementData.TileManager != null)
+                    {
+                        m_TileListElement.DrawContent();
+                    }
+                    else
+                    {
+                        EditorGUILayout.HelpBox("シーン上にタイルマネージャーが見つかりませんでした。", MessageType.Warning);
+                    }
+                });
+        }
+
+        public void AutoTexture()
+        {
+            AutoTextureAsync().ContinueWithErrorCatch();
+        }
+
+        public async Task AutoTextureAsync()
+        {
+            using (var cts = new CancellationTokenSource())
+            {
+                try
+                {
+                    CancellationToken ct = cts.Token;
+                    m_TileRebuilder = new TileRebuilder();
+                    PLATEAUTileManager tileManager = m_TileListElementData.TileManager;
+                    ObservableCollection<TileSelectionItem> selectedBuildingTiles = TileConvertCommon.FilterByPackage(PLATEAU.Dataset.PredefinedCityModelPackage.Building, m_TileListElementData.ObservableSelectedTiles, tileManager); // 建物地物に絞り込み
+
+                    List<PLATEAUDynamicTile> selectedTiles = TileConvertCommon.GetSelectedTiles(selectedBuildingTiles, tileManager);
+                    Transform editingTile = await TileConvertCommon.GetEditableTransformParent(selectedBuildingTiles, tileManager, m_TileRebuilder, ct);
+                    List<Transform> tileTransforms = TileConvertCommon.GetEditableTransforms(selectedBuildingTiles, editingTile);
+
+                    if (tileTransforms.Count > 0)
+                    {
+                        bool isOptionSelected = EditorUtility.DisplayDialog(
+                               "テクスチャ作成の確認",
+                               "テクスチャを生成します。必要に応じてHierarchy にある地物の構成が変更されることもあります。実行しますか？",
+                               "はい",
+                               "いいえ"
+                           );
+                        if (isOptionSelected)
+                        {
+                            m_ParentWindow.BlockUI();
+#if PLATEAU_SDK_222
+                            // 主要地物に変換します。
+                            PLATEAU.CityImport.Import.Convert.GranularityConvertResult result = await new CityGranularityConverter().ConvertAsync(new GranularityConvertOptionUnity(new GranularityConvertOption(ConvertGranularity.PerPrimaryFeatureObject, 1), new UniqueParentTransformList(tileTransforms), true));
+                            tileTransforms = TileConvertCommon.GetEditableTransforms(selectedBuildingTiles, editingTile); // 変換後の Tile を再取得
+#endif
+                            List<GameObject> processsingGameObjects = GetChildGameObjects(tileTransforms); // 変換後の主要地物オブジェクトをすべて取得
+                            if (PlateauRenderingBuildingUtilities.GetMeshStructure(processsingGameObjects[0]) != PlateauMeshStructure.CombinedArea && !processsingGameObjects[0].name.Contains(PlateauRenderingConstants.k_Grouped))
+                            {
+                                m_Grouping.GroupObjectsInTransform(editingTile);
+                            }
+                            var tcs = new TaskCompletionSource<bool>();
+                            void OnProcessingFinishedHandler()
+                            {
+                                // 処理完了時のコールバック
+                                m_ParentWindow.UnblockUI();
+                                m_AutoTextureProcessor.OnProcessingFinished -= OnProcessingFinishedHandler;
+                                tcs.TrySetResult(true);
+                            }
+                            m_AutoTextureProcessor.OnProcessingFinished += OnProcessingFinishedHandler;
+
+                            m_AutoTextureProcessor.RunOptimizeProcess(processsingGameObjects); // 処理開始
+
+                            await tcs.Task; // 完了待ち
+                        }
+                    }
+
+                    //tileTransforms.Clear();
+                    //tileTransforms = TileConvertCommon.GetEditableTransforms(selectedBuildingTiles, editingTile, true); // Tileとして取得し直す
+                    await TileConvertCommon.SavePrefabAssets(tileTransforms, m_TileRebuilder, ct);
+                    await m_TileRebuilder.RebuildByTiles(tileManager, selectedTiles);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogException(ex);
+                    m_TileRebuilder?.CancelRebuild();
+                }
+            }
+        }
+
+        /// <summary>
+        /// 子要素の PLATEAUCityObjectGroup をすべて取得する
+        /// </summary>
+        /// <param name="tileTransform"></param>
+        /// <returns></returns>
+        public List<GameObject> GetChildGameObjects(List<Transform> tileTransform)
+        {
+            var selectedGameObjects = new List<GameObject>();
+            foreach (Transform trans in tileTransform)
+            {
+                PLATEAUCityObjectGroup[] children = trans.GetComponentsInChildren<PLATEAUCityObjectGroup>();
+                foreach (PLATEAUCityObjectGroup child in children)
+                {
+                    selectedGameObjects.Add(child.gameObject);
+                }
+            }
+            return selectedGameObjects;
+        }
+    }
+}

--- a/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
@@ -17,16 +17,26 @@ using static PLATEAU.DynamicTile.TileConvertCommon;
 
 namespace PlateauToolkit.Rendering.Editor
 {
-    public interface IPlateauToolkitRenderingStrategy
+    /// <summary>
+    /// <see cref="PlateauToolkitRenderingWindow"/>内の処理用インターフェース
+    /// </summary>
+    interface IPlateauToolkitRenderingStrategy
     {
         SceneTileChooserType SelectedType { get; }
-        void Draw();
+        bool IsAvailable { get; }
+        bool HasConvertedObjects { get; }
+        void DrawUIForAutoTexture();
         void CreateTexture();
-
         void AddConvertedObject(GameObject obj);
+        void ResetConvertedObjects();
+        void PostApplyImageOperations(TextureEnhance textureEnhance, ComputeShader computeShader);
+        void PostImageScaling(TextureDownscaleRatio scaleRatio);
     }
 
-    public class PlateauToolkitRenderingTileStrategy : IPlateauToolkitRenderingStrategy
+    /// <summary>
+    /// <see cref="PlateauToolkitRenderingWindow"/>のタイル操作用処理
+    /// </summary>
+    class PlateauToolkitRenderingTileStrategy : IPlateauToolkitRenderingStrategy
     {
         PlateauToolkitRenderingWindow m_ParentWindow;
 
@@ -45,7 +55,17 @@ namespace PlateauToolkit.Rendering.Editor
 
         public SceneTileChooserType SelectedType => m_SceneTileChooser?.SelectedType ?? SceneTileChooserType.SceneObject;
 
-        public bool IsTileManagerSelected => m_SceneTileChooser?.SelectedType == SceneTileChooserType.DynamicTile && m_TileListElementData != null && m_TileListElementData.TileManager != null;
+        /// <summary>
+        /// シーン・タイル選択UIを使用する処理(テクスチャ生成処理)でタイル用処理を利用するかどうかを返します。
+        /// </summary>
+        public bool IsAvailable => m_SceneTileChooser?.SelectedType == SceneTileChooserType.DynamicTile && m_TileListElementData != null && m_TileListElementData.TileManager != null;
+
+
+        /// <summary>
+        /// 解像度スケール/画素パラメータをコピー時に、タイル内に変換済みオブジェクトが存在するかどうかを返します。
+        /// </summary>
+        /// <returns></returns>
+        public bool HasConvertedObjects => m_ConvertedObjectsInTile?.Count > 0;
 
         internal PlateauToolkitRenderingTileStrategy(PlateauToolkitRenderingWindow editorWindow)
         {
@@ -80,7 +100,10 @@ namespace PlateauToolkit.Rendering.Editor
             m_ConvertedObjectsInTile = new List<GameObject>();
         }
 
-        public void Draw()
+        /// <summary>
+        /// テクスチャ生成処理用にタイル選択UIを表示します。
+        /// </summary>
+        public void DrawUIForAutoTexture()
         {
             // タイル選択UIの表示
             m_SceneTileChooser.DrawAndInvoke(
@@ -110,7 +133,7 @@ namespace PlateauToolkit.Rendering.Editor
         /// <summary>
         /// 解像度スケール/画素パラメータをコピーする前に、オブジェクトのリストをリセットします。
         /// </summary>
-        public void ResetConvertedObjectsInTile()
+        public void ResetConvertedObjects()
         {
             m_ConvertedObjectsInTile.Clear();
         }
@@ -129,12 +152,6 @@ namespace PlateauToolkit.Rendering.Editor
                 }
             }
         }
-
-        /// <summary>
-        /// 解像度スケール/画素パラメータをコピー時に、タイル内に変換済みオブジェクトが存在するかどうかを返します。
-        /// </summary>
-        /// <returns></returns>
-        public bool HasConvertedObjectsInTile => m_ConvertedObjectsInTile?.Count > 0;
 
         /// <summary>
         /// テクスチャ生成処理開始
@@ -164,8 +181,8 @@ namespace PlateauToolkit.Rendering.Editor
                         CancellationToken ct = cts.Token;
                         m_TileRebuilder = new TileRebuilder();
                         PLATEAUTileManager tileManager = m_TileListElementData.TileManager;
-                        ObservableCollection<TileSelectionItem> selectedBuildingTiles = TileConvertCommon.FilterByPackage(PLATEAU.Dataset.PredefinedCityModelPackage.Building, m_TileListElementData.ObservableSelectedTiles, tileManager); // 建物地物に絞り込み
-                        await TileConvertCommon.EditAndSaveSelectedTilesAsync<ObservableCollection<TileSelectionItem>>(selectedBuildingTiles, tileManager, m_TileRebuilder, ApplyAutoTextureHandler, selectedBuildingTiles, ct);
+                        ObservableCollection<TileSelectionItem> selectedBuildingTiles = FilterByPackage(PLATEAU.Dataset.PredefinedCityModelPackage.Building, m_TileListElementData.ObservableSelectedTiles, tileManager); // 建物地物に絞り込み
+                        await EditAndSaveSelectedTilesAsync<ObservableCollection<TileSelectionItem>>(selectedBuildingTiles, tileManager, m_TileRebuilder, ApplyAutoTextureHandler, selectedBuildingTiles, ct);
                     }
                     catch (Exception ex)
                     {
@@ -180,6 +197,12 @@ namespace PlateauToolkit.Rendering.Editor
             }
         }
 
+        /// <summary>
+        /// タイル毎のテクスチャ自動生成処理
+        /// </summary>
+        /// <param name="param"></param>
+        /// <param name="selectedItems"></param>
+        /// <returns></returns>
         async Task ApplyAutoTextureHandler(EditAndSaveTilesParams param, ObservableCollection<TileSelectionItem> selectedItems)
         {
             List<Transform> tileTransforms = param.TileTransforms;
@@ -196,7 +219,7 @@ namespace PlateauToolkit.Rendering.Editor
                     PLATEAU.CityImport.Import.Convert.GranularityConvertResult result = await new CityGranularityConverter().ConvertAsync(
                         new GranularityConvertOptionUnity(
                             new GranularityConvertOption(ConvertGranularity.PerPrimaryFeatureObject, 1), new UniqueParentTransformList(convertibleTiles), true));
-                    tileTransforms = TileConvertCommon.GetEditableTransforms(selectedItems, param.EditingTile); // 変換後の Tile を再取得
+                    tileTransforms = GetEditableTransforms(selectedItems, param.EditingTile); // 変換後の Tile を再取得
                 }
 #endif
                 foreach (Transform transform in tileTransforms)
@@ -223,10 +246,14 @@ namespace PlateauToolkit.Rendering.Editor
             }
         }
 
-        internal void DrawImageFilterSaveTileButton(TextureEnhance textureEnhance, ComputeShader computeShader)
+        /// <summary>
+        /// テクスチャ調整で保存済の画素パラメータをコピーした際の後処理
+        /// </summary>
+        /// <param name="textureEnhance"></param>
+        /// <param name="computeShader"></param>
+        public void PostApplyImageOperations(TextureEnhance textureEnhance, ComputeShader computeShader)
         {
-
-            if (!HasConvertedObjectsInTile)
+            if (!HasConvertedObjects)
             {
                 return;
             }
@@ -238,7 +265,7 @@ namespace PlateauToolkit.Rendering.Editor
                     SaveSelectedTilesImageFilterAsync(textureEnhance, computeShader).ContinueWithErrorCatch();
                 }
 
-                ResetConvertedObjectsInTile();
+                ResetConvertedObjects();
             };
         }
 
@@ -252,7 +279,7 @@ namespace PlateauToolkit.Rendering.Editor
                 {
                     CancellationToken ct = cts.Token;
                     m_TileRebuilder = new TileRebuilder();
-                    await TileConvertCommon.EditAndSaveSelectedTilesAsync<(TextureEnhance, ComputeShader)>(m_ConvertedObjectsInTile, m_TileRebuilder, ApplyFilterHandler, (textureEnhance, computeShader), ct);
+                    await EditAndSaveSelectedTilesAsync<(TextureEnhance, ComputeShader)>(m_ConvertedObjectsInTile, m_TileRebuilder, ApplyFilterHandler, (textureEnhance, computeShader), ct);
                 }
             }
             catch (Exception ex)
@@ -266,6 +293,12 @@ namespace PlateauToolkit.Rendering.Editor
             }
         }
 
+        /// <summary>
+        /// タイル毎のテクスチャ調整処理
+        /// </summary>
+        /// <param name="param"></param>
+        /// <param name="tparam"></param>
+        /// <returns></returns>
         Task ApplyFilterHandler(EditAndSaveTilesParams param, (TextureEnhance, ComputeShader) tparam)
         {
             List<Transform> tileTransforms = param.TileTransforms;
@@ -298,9 +331,13 @@ namespace PlateauToolkit.Rendering.Editor
             return Task.CompletedTask;
         }
 
-        internal void DrawImageScalingSaveTileButton(TextureDownscaleRatio scaleRatio)
+        /// <summary>
+        /// 解像度変更で保存した解像度スケールのコピー後の処理
+        /// </summary>
+        /// <param name="scaleRatio"></param>
+        public void PostImageScaling(TextureDownscaleRatio scaleRatio)
         {
-            if (!HasConvertedObjectsInTile)
+            if (!HasConvertedObjects)
             {
                 return;
             }
@@ -312,7 +349,7 @@ namespace PlateauToolkit.Rendering.Editor
                     SaveSelectedTilesImageScalingAsync(scaleRatio).ContinueWithErrorCatch();
                 }
 
-                ResetConvertedObjectsInTile();
+                ResetConvertedObjects();
             };
         }
 
@@ -326,7 +363,7 @@ namespace PlateauToolkit.Rendering.Editor
                 {
                     CancellationToken ct = cts.Token;
                     m_TileRebuilder = new TileRebuilder();
-                    await TileConvertCommon.EditAndSaveSelectedTilesAsync<TextureDownscaleRatio>(m_ConvertedObjectsInTile, m_TileRebuilder, ApplyImageScalingHandler, scaleRatio, ct);
+                    await EditAndSaveSelectedTilesAsync<TextureDownscaleRatio>(m_ConvertedObjectsInTile, m_TileRebuilder, ApplyImageScalingHandler, scaleRatio, ct);
                 }
             }
             catch(Exception ex)
@@ -340,6 +377,12 @@ namespace PlateauToolkit.Rendering.Editor
             }
         }
 
+        /// <summary>
+        /// タイル毎の解像度変更処理
+        /// </summary>
+        /// <param name="param"></param>
+        /// <param name="scaleRatio"></param>
+        /// <returns></returns>
         Task ApplyImageScalingHandler(EditAndSaveTilesParams param, TextureDownscaleRatio scaleRatio)
         {
             List<Transform> tileTransforms = param.TileTransforms;
@@ -375,7 +418,7 @@ namespace PlateauToolkit.Rendering.Editor
         /// </summary>
         /// <param name="tileTransform"></param>
         /// <returns></returns>
-        public List<GameObject> GetChildGameObjects(Transform tileTransform)
+        List<GameObject> GetChildGameObjects(Transform tileTransform)
         {
             var selectedGameObjects = new List<GameObject>();
             PLATEAUCityObjectGroup[] children = tileTransform.GetComponentsInChildren<PLATEAUCityObjectGroup>();

--- a/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
@@ -21,6 +21,8 @@ namespace PlateauToolkit.Rendering.Editor
         SceneTileChooserType SelectedType { get; }
         void Draw();
         void CreateTexture();
+
+        void AddConvertedObject(GameObject obj);
     }
 
     public class PlateauToolkitRenderingTileStrategy : IPlateauToolkitRenderingStrategy
@@ -37,6 +39,8 @@ namespace PlateauToolkit.Rendering.Editor
         AutoTexturing m_AutoTextureProcessor;
         // LOD grouping
         Grouping m_Grouping;
+
+        List<GameObject> m_ConvertedObjectsInTile;
 
         public SceneTileChooserType SelectedType => m_SceneTileChooser?.SelectedType ?? SceneTileChooserType.SceneObject;
 
@@ -71,6 +75,8 @@ namespace PlateauToolkit.Rendering.Editor
                 m_AutoTextureProcessor = new AutoTexturing();
                 m_AutoTextureProcessor.Initialize();
             }
+
+            m_ConvertedObjectsInTile = new List<GameObject>();
         }
 
         public void Draw()
@@ -100,6 +106,38 @@ namespace PlateauToolkit.Rendering.Editor
                 });
         }
 
+        /// <summary>
+        /// 解像度スケール/画素パラメータをコピーする前に、オブジェクトのリストをリセットします。
+        /// </summary>
+        public void ResetConvertedObjectsInTile()
+        {
+            m_ConvertedObjectsInTile.Clear();
+        }
+
+        /// <summary>
+        /// 解像度スケール/画素パラメータをコピーした際に、タイル内の変換済みオブジェクトをリストに追加します。
+        /// </summary>
+        /// <param name="obj"></param>
+        public void AddConvertedObject(GameObject obj)
+        {
+            if (obj.GetComponentInParent<PLATEAUTileManager>() != null)
+            {
+                if (!m_ConvertedObjectsInTile.Contains(obj))
+                {
+                    m_ConvertedObjectsInTile.Add(obj);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 解像度スケール/画素パラメータをコピー時に、タイル内に変換済みオブジェクトが存在するかどうかを返します。
+        /// </summary>
+        /// <returns></returns>
+        public bool HasConvertedObjectsInTile => m_ConvertedObjectsInTile?.Count > 0;
+
+        /// <summary>
+        /// テクスチャ生成処理開始
+        /// </summary>
         public void CreateTexture()
         {
             AutoTextureAsync().ContinueWithErrorCatch();
@@ -184,6 +222,147 @@ namespace PlateauToolkit.Rendering.Editor
                         m_ParentWindow.UnblockUI();
                     }
                 }
+            }
+        }
+
+        internal void DrawImageFilterSaveTileButton(TextureEnhance textureEnhance, ComputeShader computeShader)
+        {
+
+            if (!HasConvertedObjectsInTile)
+            {
+                return;
+            }
+
+            bool isOptionSelected = EditorUtility.DisplayDialog(
+                "タイル保存の確認",
+                "変更されたテクスチャを含むタイルを保存しなおします。実行しますか？",
+                "はい",
+                "いいえ"
+            );
+
+            //EditorGUILayout.Space(5);
+            //if (GUILayout.Button("選択したオブジェクトのタイルを保存する"))
+            if (isOptionSelected)
+            {
+                SaveSelectedTilesImageFilterAsync(textureEnhance, computeShader).ContinueWithErrorCatch();
+            }
+
+            ResetConvertedObjectsInTile();
+        }
+
+        async Task SaveSelectedTilesImageFilterAsync(TextureEnhance textureEnhance, ComputeShader computeShader)
+        {
+            m_ParentWindow.BlockUI();
+
+            try
+            {
+                //List<GameObject> selectedObjects = new List<GameObject>(Selection.gameObjects);
+                using (var cts = new CancellationTokenSource())
+                {
+                    CancellationToken ct = cts.Token;
+                    m_TileRebuilder = new TileRebuilder();
+                    await TileConvertCommon.EditAndSaveSelectedTilesAsync<(TextureEnhance, ComputeShader)>(m_ConvertedObjectsInTile, m_TileRebuilder, ApplyFilterHandler, (textureEnhance, computeShader), ct);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+                m_TileRebuilder?.CancelRebuild();
+            }
+            finally
+            {
+                m_ParentWindow.UnblockUI();
+            }
+        }
+
+        void ApplyFilterHandler(Transform target, (TextureEnhance, ComputeShader) param )
+        {
+            (TextureEnhance textureEnhance, ComputeShader computeShader) = param;
+            List<Transform> children = target.GetAllChildrenWithComponent<MeshRenderer>();
+            foreach (Transform child in children)
+            {
+                GameObject targetGameObject = child.gameObject;
+                if (PlateauRenderingBuildingUtilities.IsObjectAutoTextured(targetGameObject))
+                {
+                    continue;
+                }
+
+                if (PlateauRenderingBuildingUtilities.GetMeshLodLevel(targetGameObject) != PlateauMeshLodLevel.Lod2)
+                {
+                    continue;
+                }
+
+                m_ParentWindow.ApplyImageOperationsForObject(targetGameObject, textureEnhance, computeShader);
+            }
+        }
+
+        internal void DrawImageScalingSaveTileButton(TextureDownscaleRatio scaleRatio)
+        {
+            Debug.Log("DrawImageScalingSaveTileButton called");
+
+            if (!HasConvertedObjectsInTile)
+            {
+                return;
+            }
+
+            bool isOptionSelected = EditorUtility.DisplayDialog(
+                "タイル保存の確認",
+                "変更されたテクスチャを含むタイルを保存しなおします。実行しますか？",
+                "はい",
+                "いいえ"
+            );
+
+            //EditorGUILayout.Space(5);
+            //if (GUILayout.Button("選択したオブジェクトのタイルを保存する"))
+            if (isOptionSelected)
+            {
+                SaveSelectedTilesImageScalingAsync(scaleRatio).ContinueWithErrorCatch();
+            }
+
+            ResetConvertedObjectsInTile();
+        }
+
+        async Task SaveSelectedTilesImageScalingAsync(TextureDownscaleRatio scaleRatio)
+        {
+            m_ParentWindow.BlockUI();
+
+            try
+            {
+                using (var cts = new CancellationTokenSource())
+                {
+                    CancellationToken ct = cts.Token;
+                    m_TileRebuilder = new TileRebuilder();
+                    await TileConvertCommon.EditAndSaveSelectedTilesAsync<TextureDownscaleRatio>(m_ConvertedObjectsInTile, m_TileRebuilder, ApplyImageScalingHandler, scaleRatio, ct);
+                }
+            }
+            catch(Exception ex)
+            {
+                Debug.LogException(ex);
+                m_TileRebuilder?.CancelRebuild();
+            }
+            finally
+            {
+                m_ParentWindow.UnblockUI();
+            }
+        }
+
+        void ApplyImageScalingHandler(Transform target, TextureDownscaleRatio scaleRatio)
+        {
+            List<Transform> children = target.GetAllChildrenWithComponent<MeshRenderer>();
+            foreach (Transform child in children)
+            {
+                GameObject targetGameObject = child.gameObject;
+                if (PlateauRenderingBuildingUtilities.IsObjectAutoTextured(targetGameObject))
+                {
+                    continue;
+                }
+
+                if (PlateauRenderingBuildingUtilities.GetMeshLodLevel(targetGameObject) != PlateauMeshLodLevel.Lod2)
+                {
+                    continue;
+                }
+
+                m_ParentWindow.ApplyImageScalingForObject(targetGameObject, scaleRatio);
             }
         }
 

--- a/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
+using static PLATEAU.DynamicTile.TileConvertCommon;
 
 namespace PlateauToolkit.Rendering.Editor
 {
@@ -164,53 +165,7 @@ namespace PlateauToolkit.Rendering.Editor
                         m_TileRebuilder = new TileRebuilder();
                         PLATEAUTileManager tileManager = m_TileListElementData.TileManager;
                         ObservableCollection<TileSelectionItem> selectedBuildingTiles = TileConvertCommon.FilterByPackage(PLATEAU.Dataset.PredefinedCityModelPackage.Building, m_TileListElementData.ObservableSelectedTiles, tileManager); // 建物地物に絞り込み
-
-                        List<PLATEAUDynamicTile> selectedTiles = TileConvertCommon.GetSelectedTiles(selectedBuildingTiles, tileManager);
-                        Transform editingTile = await TileConvertCommon.GetEditableTransformParent(selectedBuildingTiles, tileManager, m_TileRebuilder, ct);
-                        List<Transform> tileTransforms = TileConvertCommon.GetEditableTransforms(selectedBuildingTiles, editingTile);
-
-                        if (tileTransforms.Count > 0)
-                        {
-
-#if PLATEAU_SDK_222
-
-                            IEnumerable<Transform> convertibleTiles = tileTransforms.Where(t => Enumerable.Range(0, t.childCount)
-                              .Select(i => t.GetChild(i).name).All(n => n.StartsWith("LOD"))); // タイル直下の子が全てLODであるタイルのみ抽出 (改造構造が変わっていると変換できない）
-                            if (convertibleTiles.Any())
-                            {
-                                // 主要地物に変換します。
-                                PLATEAU.CityImport.Import.Convert.GranularityConvertResult result = await new CityGranularityConverter().ConvertAsync(
-                                    new GranularityConvertOptionUnity(
-                                        new GranularityConvertOption(ConvertGranularity.PerPrimaryFeatureObject, 1), new UniqueParentTransformList(convertibleTiles), true));
-                                tileTransforms = TileConvertCommon.GetEditableTransforms(selectedBuildingTiles, editingTile); // 変換後の Tile を再取得
-                            }
-#endif
-                            foreach (Transform transform in tileTransforms)
-                            {
-                                List<GameObject> processsingGameObjects = GetChildGameObjects(transform);
-                                if (PlateauRenderingBuildingUtilities.GetMeshStructure(processsingGameObjects.First()) != PlateauMeshStructure.CombinedArea && !processsingGameObjects.First().name.Contains(PlateauRenderingConstants.k_Grouped))
-                                {
-                                    m_Grouping.GroupObjectsInTransform(transform);
-                                    processsingGameObjects.RemoveAll(go => go == null);
-                                }
-
-                                var tcs = new TaskCompletionSource<bool>();
-                                void OnProcessingFinishedHandler()
-                                {
-                                    // 処理完了時のコールバック
-                                    m_AutoTextureProcessor.OnProcessingFinished -= OnProcessingFinishedHandler;
-                                    tcs.TrySetResult(true);
-                                }
-
-                                m_AutoTextureProcessor.OnProcessingFinished += OnProcessingFinishedHandler;
-                                m_AutoTextureProcessor.RunOptimizeProcess(processsingGameObjects); // 処理開始
-                                await tcs.Task; // 完了待ち
-                            }
-                        }
-
-                        tileTransforms = TileConvertCommon.GetEditableTransforms(selectedBuildingTiles, editingTile, true); // Tileとして取得し直す
-                        await TileConvertCommon.SavePrefabAssets(tileTransforms, m_TileRebuilder, ct);
-                        await m_TileRebuilder.RebuildByTiles(tileManager, selectedTiles);
+                        await TileConvertCommon.EditAndSaveSelectedTilesAsync<ObservableCollection<TileSelectionItem>>(selectedBuildingTiles, tileManager, m_TileRebuilder, ApplyAutoTextureHandler, selectedBuildingTiles, ct);
                     }
                     catch (Exception ex)
                     {
@@ -225,6 +180,49 @@ namespace PlateauToolkit.Rendering.Editor
             }
         }
 
+        async Task ApplyAutoTextureHandler(EditAndSaveTilesParams param, ObservableCollection<TileSelectionItem> selectedItems)
+        {
+            List<Transform> tileTransforms = param.TileTransforms;
+            if (param.TileTransforms.Count > 0)
+            {
+
+#if PLATEAU_SDK_222
+
+                IEnumerable<Transform> convertibleTiles = tileTransforms.Where(t => Enumerable.Range(0, t.childCount)
+                  .Select(i => t.GetChild(i).name).All(n => n.StartsWith("LOD"))); // タイル直下の子が全てLODであるタイルのみ抽出 (改造構造が変わっていると変換できない）
+                if (convertibleTiles.Any())
+                {
+                    // 主要地物に変換します。
+                    PLATEAU.CityImport.Import.Convert.GranularityConvertResult result = await new CityGranularityConverter().ConvertAsync(
+                        new GranularityConvertOptionUnity(
+                            new GranularityConvertOption(ConvertGranularity.PerPrimaryFeatureObject, 1), new UniqueParentTransformList(convertibleTiles), true));
+                    tileTransforms = TileConvertCommon.GetEditableTransforms(selectedItems, param.EditingTile); // 変換後の Tile を再取得
+                }
+#endif
+                foreach (Transform transform in tileTransforms)
+                {
+                    List<GameObject> processsingGameObjects = GetChildGameObjects(transform);
+                    if (PlateauRenderingBuildingUtilities.GetMeshStructure(processsingGameObjects.First()) != PlateauMeshStructure.CombinedArea && !processsingGameObjects.First().name.Contains(PlateauRenderingConstants.k_Grouped))
+                    {
+                        m_Grouping.GroupObjectsInTransform(transform);
+                        processsingGameObjects.RemoveAll(go => go == null);
+                    }
+
+                    var tcs = new TaskCompletionSource<bool>();
+                    void OnProcessingFinishedHandler()
+                    {
+                        // 処理完了時のコールバック
+                        m_AutoTextureProcessor.OnProcessingFinished -= OnProcessingFinishedHandler;
+                        tcs.TrySetResult(true);
+                    }
+
+                    m_AutoTextureProcessor.OnProcessingFinished += OnProcessingFinishedHandler;
+                    m_AutoTextureProcessor.RunOptimizeProcess(processsingGameObjects); // 処理開始
+                    await tcs.Task; // 完了待ち
+                }
+            }
+        }
+
         internal void DrawImageFilterSaveTileButton(TextureEnhance textureEnhance, ComputeShader computeShader)
         {
 
@@ -235,14 +233,7 @@ namespace PlateauToolkit.Rendering.Editor
 
             EditorApplication.delayCall += () =>
             {
-                bool isOptionSelected = EditorUtility.DisplayDialog(
-                    "タイル保存の確認",
-                    "変更されたテクスチャを含むタイルを保存しなおします。実行しますか？",
-                    "はい",
-                    "いいえ"
-                );
-
-                if (isOptionSelected)
+                if (ConfirmTileSave())
                 {
                     SaveSelectedTilesImageFilterAsync(textureEnhance, computeShader).ContinueWithErrorCatch();
                 }
@@ -275,25 +266,36 @@ namespace PlateauToolkit.Rendering.Editor
             }
         }
 
-        void ApplyFilterHandler(Transform target, (TextureEnhance, ComputeShader) param )
+        Task ApplyFilterHandler(EditAndSaveTilesParams param, (TextureEnhance, ComputeShader) tparam)
         {
-            (TextureEnhance textureEnhance, ComputeShader computeShader) = param;
-            List<Transform> children = target.GetAllChildrenWithComponent<MeshRenderer>();
-            foreach (Transform child in children)
+            List<Transform> tileTransforms = param.TileTransforms;
+            (TextureEnhance textureEnhance, ComputeShader computeShader) = tparam;
+
+            foreach (Transform target in tileTransforms)
             {
-                GameObject targetGameObject = child.gameObject;
-                if (PlateauRenderingBuildingUtilities.IsObjectAutoTextured(targetGameObject))
+                if (target == null)
                 {
                     continue;
                 }
 
-                if (PlateauRenderingBuildingUtilities.GetMeshLodLevel(targetGameObject) != PlateauMeshLodLevel.Lod2)
+                List<Transform> children = target.GetAllChildrenWithComponent<MeshRenderer>();
+                foreach (Transform child in children)
                 {
-                    continue;
-                }
+                    GameObject targetGameObject = child.gameObject;
+                    if (PlateauRenderingBuildingUtilities.IsObjectAutoTextured(targetGameObject))
+                    {
+                        continue;
+                    }
 
-                m_ParentWindow.ApplyImageOperationsForObject(targetGameObject, textureEnhance, computeShader);
+                    if (PlateauRenderingBuildingUtilities.GetMeshLodLevel(targetGameObject) != PlateauMeshLodLevel.Lod2)
+                    {
+                        continue;
+                    }
+
+                    m_ParentWindow.ApplyImageOperationsForObject(targetGameObject, textureEnhance, computeShader);
+                }
             }
+            return Task.CompletedTask;
         }
 
         internal void DrawImageScalingSaveTileButton(TextureDownscaleRatio scaleRatio)
@@ -305,14 +307,7 @@ namespace PlateauToolkit.Rendering.Editor
 
             EditorApplication.delayCall += () =>
             {
-                bool isOptionSelected = EditorUtility.DisplayDialog(
-                    "タイル保存の確認",
-                    "変更されたテクスチャを含むタイルを保存しなおします。実行しますか？",
-                    "はい",
-                    "いいえ"
-                );
-
-                if (isOptionSelected)
+                if (ConfirmTileSave())
                 {
                     SaveSelectedTilesImageScalingAsync(scaleRatio).ContinueWithErrorCatch();
                 }
@@ -345,24 +340,34 @@ namespace PlateauToolkit.Rendering.Editor
             }
         }
 
-        void ApplyImageScalingHandler(Transform target, TextureDownscaleRatio scaleRatio)
+        Task ApplyImageScalingHandler(EditAndSaveTilesParams param, TextureDownscaleRatio scaleRatio)
         {
-            List<Transform> children = target.GetAllChildrenWithComponent<MeshRenderer>();
-            foreach (Transform child in children)
+            List<Transform> tileTransforms = param.TileTransforms;
+            foreach (Transform target in tileTransforms)
             {
-                GameObject targetGameObject = child.gameObject;
-                if (PlateauRenderingBuildingUtilities.IsObjectAutoTextured(targetGameObject))
+                if (target == null)
                 {
                     continue;
                 }
 
-                if (PlateauRenderingBuildingUtilities.GetMeshLodLevel(targetGameObject) != PlateauMeshLodLevel.Lod2)
+                List<Transform> children = target.GetAllChildrenWithComponent<MeshRenderer>();
+                foreach (Transform child in children)
                 {
-                    continue;
-                }
+                    GameObject targetGameObject = child.gameObject;
+                    if (PlateauRenderingBuildingUtilities.IsObjectAutoTextured(targetGameObject))
+                    {
+                        continue;
+                    }
 
-                m_ParentWindow.ApplyImageScalingForObject(targetGameObject, scaleRatio);
+                    if (PlateauRenderingBuildingUtilities.GetMeshLodLevel(targetGameObject) != PlateauMeshLodLevel.Lod2)
+                    {
+                        continue;
+                    }
+
+                    m_ParentWindow.ApplyImageScalingForObject(targetGameObject, scaleRatio);
+                }
             }
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -379,6 +384,20 @@ namespace PlateauToolkit.Rendering.Editor
                 selectedGameObjects.Add(child.gameObject);
             }
             return selectedGameObjects;
+        }
+
+        /// <summary>
+        /// タイル保存の確認ダイアログを表示します。
+        /// </summary>
+        /// <returns></returns>
+        bool ConfirmTileSave()
+        {
+            return EditorUtility.DisplayDialog(
+                "タイル保存の確認",
+                "変更されたテクスチャを含むタイルを更新して保存します。実行しますか？",
+                "はい",
+                "いいえ"
+            );
         }
     }
 }

--- a/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs
@@ -233,21 +233,22 @@ namespace PlateauToolkit.Rendering.Editor
                 return;
             }
 
-            bool isOptionSelected = EditorUtility.DisplayDialog(
-                "タイル保存の確認",
-                "変更されたテクスチャを含むタイルを保存しなおします。実行しますか？",
-                "はい",
-                "いいえ"
-            );
-
-            //EditorGUILayout.Space(5);
-            //if (GUILayout.Button("選択したオブジェクトのタイルを保存する"))
-            if (isOptionSelected)
+            EditorApplication.delayCall += () =>
             {
-                SaveSelectedTilesImageFilterAsync(textureEnhance, computeShader).ContinueWithErrorCatch();
-            }
+                bool isOptionSelected = EditorUtility.DisplayDialog(
+                    "タイル保存の確認",
+                    "変更されたテクスチャを含むタイルを保存しなおします。実行しますか？",
+                    "はい",
+                    "いいえ"
+                );
 
-            ResetConvertedObjectsInTile();
+                if (isOptionSelected)
+                {
+                    SaveSelectedTilesImageFilterAsync(textureEnhance, computeShader).ContinueWithErrorCatch();
+                }
+
+                ResetConvertedObjectsInTile();
+            };
         }
 
         async Task SaveSelectedTilesImageFilterAsync(TextureEnhance textureEnhance, ComputeShader computeShader)
@@ -256,7 +257,6 @@ namespace PlateauToolkit.Rendering.Editor
 
             try
             {
-                //List<GameObject> selectedObjects = new List<GameObject>(Selection.gameObjects);
                 using (var cts = new CancellationTokenSource())
                 {
                     CancellationToken ct = cts.Token;
@@ -298,28 +298,27 @@ namespace PlateauToolkit.Rendering.Editor
 
         internal void DrawImageScalingSaveTileButton(TextureDownscaleRatio scaleRatio)
         {
-            Debug.Log("DrawImageScalingSaveTileButton called");
-
             if (!HasConvertedObjectsInTile)
             {
                 return;
             }
 
-            bool isOptionSelected = EditorUtility.DisplayDialog(
-                "タイル保存の確認",
-                "変更されたテクスチャを含むタイルを保存しなおします。実行しますか？",
-                "はい",
-                "いいえ"
-            );
-
-            //EditorGUILayout.Space(5);
-            //if (GUILayout.Button("選択したオブジェクトのタイルを保存する"))
-            if (isOptionSelected)
+            EditorApplication.delayCall += () =>
             {
-                SaveSelectedTilesImageScalingAsync(scaleRatio).ContinueWithErrorCatch();
-            }
+                bool isOptionSelected = EditorUtility.DisplayDialog(
+                    "タイル保存の確認",
+                    "変更されたテクスチャを含むタイルを保存しなおします。実行しますか？",
+                    "はい",
+                    "いいえ"
+                );
 
-            ResetConvertedObjectsInTile();
+                if (isOptionSelected)
+                {
+                    SaveSelectedTilesImageScalingAsync(scaleRatio).ContinueWithErrorCatch();
+                }
+
+                ResetConvertedObjectsInTile();
+            };
         }
 
         async Task SaveSelectedTilesImageScalingAsync(TextureDownscaleRatio scaleRatio)

--- a/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs.meta
+++ b/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingTileStrategy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72bfbee0fce5d9f47b4b66ac11787e1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingWindow.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingWindow.cs
@@ -398,7 +398,7 @@ namespace PlateauToolkit.Rendering.Editor
                     EditorGUI.BeginChangeCheck();
                     if (GUILayout.Button("テクスチャ生成"))
                     {
-                        if (m_RenderingTileStrategy?.IsTileManagerSelected == true)
+                        if (IsTileSelected())
                         {
                             // タイル用処理
                             m_RenderingTileStrategy.CreateTexture();
@@ -789,6 +789,8 @@ namespace PlateauToolkit.Rendering.Editor
                         if (GUILayout.Button("選択したオブジェクトのテクスチャに保存済の画素パラメータをコピーする"))
                         {
                             ApplyImageOperations();
+
+                            m_RenderingTileStrategy?.DrawImageFilterSaveTileButton(m_TextureEnhance, m_ComputeShader);
                         }
                         EditorGUILayout.EndVertical();
                     }
@@ -972,7 +974,10 @@ namespace PlateauToolkit.Rendering.Editor
                         if (GUILayout.Button("選択したオブジェクトのテクスチャに保存済の解像度スケールをコピーします"))
                         {
                             ApplyImageScaling();
+
+                            m_RenderingTileStrategy?.DrawImageScalingSaveTileButton(m_TextureDownscaleRatio);
                         }
+
                         EditorGUILayout.EndVertical();
                     }
 
@@ -1060,6 +1065,9 @@ namespace PlateauToolkit.Rendering.Editor
 
         void ApplyImageScaling()
         {
+            //m_SelectedObjectIsInTile = false;
+            m_RenderingTileStrategy?.ResetConvertedObjectsInTile();
+
             GameObject[] selectedObjects = Selection.gameObjects;
             foreach (GameObject gameObject in selectedObjects)
             {
@@ -1081,61 +1089,72 @@ namespace PlateauToolkit.Rendering.Editor
                     continue;
                 }
 
-                MeshRenderer mr = gameObject.GetComponent<MeshRenderer>();
-                MeshFilter mf = gameObject.GetComponent<MeshFilter>();
-
-                // Check for Mesh Filter and Mesh Renderer components
-                if (mf != null && mr != null)
+                if (ApplyImageScalingForObject(gameObject, m_TextureDownscaleRatio))
                 {
-                    Material[] materials = mr.sharedMaterials;
-
-                    foreach (Material mat in materials)
-                    {
-                        if (mat.mainTexture == null)
-                        {
-                            continue;
-                        }
-
-                        // Record the material before changing the texture
-                        Undo.RecordObject(mat, "Scale Texture");
-
-                        int newWidth = mat.mainTexture.width;
-                        int newHeight = mat.mainTexture.height;
-                        switch (m_TextureDownscaleRatio)
-                        {
-                            case TextureDownscaleRatio.None:
-                                break;
-                            case TextureDownscaleRatio.Quarter:
-                                newWidth /= 4;
-                                newHeight /= 4;
-                                mat.mainTexture = TextureScaler.Resize(mat.mainTexture as Texture2D, newWidth, newHeight);
-                                break;
-                            case TextureDownscaleRatio.Half:
-                                newWidth /= 2;
-                                newHeight /= 2;
-                                mat.mainTexture = TextureScaler.Resize(mat.mainTexture as Texture2D, newWidth, newHeight);
-                                break;
-                            case TextureDownscaleRatio.OneEighth:
-                                newWidth /= 8;
-                                newHeight /= 8;
-                                mat.mainTexture = TextureScaler.Resize(mat.mainTexture as Texture2D, newWidth, newHeight);
-                                break;
-                            case TextureDownscaleRatio.OneSixteenth:
-                                newWidth /= 16;
-                                newHeight /= 16;
-                                mat.mainTexture = TextureScaler.Resize(mat.mainTexture as Texture2D, newWidth, newHeight);
-                                break;
-
-                        }
-                    }
+                    m_RenderingTileStrategy?.AddConvertedObject(gameObject);
                 }
             }
         }
 
+        internal bool ApplyImageScalingForObject(GameObject target, TextureDownscaleRatio scaleRatio)
+        {
+            MeshRenderer mr = target.GetComponent<MeshRenderer>();
+            MeshFilter mf = target.GetComponent<MeshFilter>();
+
+            // Check for Mesh Filter and Mesh Renderer components
+            if (mf != null && mr != null)
+            {
+                Material[] materials = mr.sharedMaterials;
+
+                foreach (Material mat in materials)
+                {
+                    if (mat.mainTexture == null)
+                    {
+                        continue;
+                    }
+
+                    // Record the material before changing the texture
+                    Undo.RecordObject(mat, "Scale Texture");
+
+                    int newWidth = mat.mainTexture.width;
+                    int newHeight = mat.mainTexture.height;
+                    switch (scaleRatio)
+                    {
+                        case TextureDownscaleRatio.None:
+                            break;
+                        case TextureDownscaleRatio.Quarter:
+                            newWidth /= 4;
+                            newHeight /= 4;
+                            mat.mainTexture = TextureScaler.Resize(mat.mainTexture as Texture2D, newWidth, newHeight);
+                            break;
+                        case TextureDownscaleRatio.Half:
+                            newWidth /= 2;
+                            newHeight /= 2;
+                            mat.mainTexture = TextureScaler.Resize(mat.mainTexture as Texture2D, newWidth, newHeight);
+                            break;
+                        case TextureDownscaleRatio.OneEighth:
+                            newWidth /= 8;
+                            newHeight /= 8;
+                            mat.mainTexture = TextureScaler.Resize(mat.mainTexture as Texture2D, newWidth, newHeight);
+                            break;
+                        case TextureDownscaleRatio.OneSixteenth:
+                            newWidth /= 16;
+                            newHeight /= 16;
+                            mat.mainTexture = TextureScaler.Resize(mat.mainTexture as Texture2D, newWidth, newHeight);
+                            break;
+
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
         void ApplyImageOperations()
         {
-            GameObject[] selectedObjects = Selection.gameObjects;
+            m_RenderingTileStrategy?.ResetConvertedObjectsInTile();
 
+            GameObject[] selectedObjects = Selection.gameObjects;
             foreach (GameObject gameObject in selectedObjects)
             {
                 // Check if the GameObject is part of a prefab
@@ -1156,60 +1175,72 @@ namespace PlateauToolkit.Rendering.Editor
                     continue;
                 }
 
-                MeshRenderer meshRenderer = gameObject.GetComponent<MeshRenderer>();
-                MeshFilter meshFilter = gameObject.GetComponent<MeshFilter>();
-
-                // Check for Mesh Filter and Mesh Renderer components
-                if (meshFilter != null && meshRenderer != null)
+                if (ApplyImageOperationsForObject(gameObject, m_TextureEnhance, m_ComputeShader))
                 {
-                    (Material original, int materialIndex) = PlateauRenderingMeshUtilities.GetSubmaterialAndIndexByLargestFaceArea(meshRenderer, meshFilter.sharedMesh);
-                    Material newMat = new Material(original);
-
-                    // apply the image processing on the texture
-                    foreach (ImageEditOperation op in m_TextureEnhance.ReadOnlyOperationsList)
-                    {
-                        IPlateauRenderingImageFilter filter = null;
-                        switch (op.ImageParam)
-                        {
-                            case ImageEditParameters.HighPass:
-                                if (filter == null && op.ImageParamValue != 0)
-                                {
-                                    filter = new PlateauRenderingHighPassFilter();
-                                }
-                                break;
-                            case ImageEditParameters.Contrast:
-                                if (filter == null && op.ImageParamValue != 0)
-                                {
-                                    filter = new PlateauRenderingContrastFilter();
-                                }
-                                break;
-                            case ImageEditParameters.Brightness:
-                                if (filter == null && op.ImageParamValue != 0)
-                                {
-                                    filter = new PlateauRenderingBrightnessFilter();
-                                }
-                                break;
-                            case ImageEditParameters.Sharpness:
-                                if (filter == null && op.ImageParamValue != 0)
-                                {
-                                    filter = new PlateauRenderingSharpenFilter();
-                                }
-                                break;
-                        }
-                        if (filter != null && newMat.mainTexture != null)
-                        {
-                            newMat.mainTexture = filter.ApplyFilter(newMat.mainTexture, m_ComputeShader, op.ImageParamValue);
-                        }
-                    }
-
-                    // Register the undo operation for the material changes
-                    Undo.RegisterCompleteObjectUndo(meshRenderer, "Material Change");
-
-                    Material[] sharedMaterials = meshRenderer.sharedMaterials;
-                    sharedMaterials[materialIndex] = newMat;
-                    meshRenderer.sharedMaterials = sharedMaterials;
+                    m_RenderingTileStrategy?.AddConvertedObject(gameObject);
                 }
             }
+        }
+
+        internal bool ApplyImageOperationsForObject(GameObject target, TextureEnhance textureEnhance, ComputeShader computeShader)
+        {
+
+            MeshRenderer meshRenderer = target.GetComponent<MeshRenderer>();
+            MeshFilter meshFilter = target.GetComponent<MeshFilter>();
+
+            // Check for Mesh Filter and Mesh Renderer components
+            if (meshFilter != null && meshRenderer != null)
+            {
+                (Material original, int materialIndex) = PlateauRenderingMeshUtilities.GetSubmaterialAndIndexByLargestFaceArea(meshRenderer, meshFilter.sharedMesh);
+                Material newMat = new Material(original);
+
+                // apply the image processing on the texture
+                foreach (ImageEditOperation op in textureEnhance.ReadOnlyOperationsList)
+                {
+                    IPlateauRenderingImageFilter filter = null;
+                    switch (op.ImageParam)
+                    {
+                        case ImageEditParameters.HighPass:
+                            if (filter == null && op.ImageParamValue != 0)
+                            {
+                                filter = new PlateauRenderingHighPassFilter();
+                            }
+                            break;
+                        case ImageEditParameters.Contrast:
+                            if (filter == null && op.ImageParamValue != 0)
+                            {
+                                filter = new PlateauRenderingContrastFilter();
+                            }
+                            break;
+                        case ImageEditParameters.Brightness:
+                            if (filter == null && op.ImageParamValue != 0)
+                            {
+                                filter = new PlateauRenderingBrightnessFilter();
+                            }
+                            break;
+                        case ImageEditParameters.Sharpness:
+                            if (filter == null && op.ImageParamValue != 0)
+                            {
+                                filter = new PlateauRenderingSharpenFilter();
+                            }
+                            break;
+                    }
+                    if (filter != null && newMat.mainTexture != null)
+                    {
+                        newMat.mainTexture = filter.ApplyFilter(newMat.mainTexture, computeShader, op.ImageParamValue);
+                    }
+                }
+
+                // Register the undo operation for the material changes
+                Undo.RegisterCompleteObjectUndo(meshRenderer, "Material Change");
+
+                Material[] sharedMaterials = meshRenderer.sharedMaterials;
+                sharedMaterials[materialIndex] = newMat;
+                meshRenderer.sharedMaterials = sharedMaterials;
+
+                return true;
+            }
+            return false;
         }
 
         bool SelectedBuildings()
@@ -1354,6 +1385,15 @@ namespace PlateauToolkit.Rendering.Editor
             {
                 return false;
             }
+        }
+
+        /// <summary>
+        /// 動的タイルが選択されているかどうか
+        /// </summary>
+        /// <returns></returns>
+        bool IsTileSelected()
+        {
+            return m_RenderingTileStrategy?.IsTileManagerSelected == true;
         }
 
         bool CanImageEditSelection()

--- a/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingWindow.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingWindow.cs
@@ -14,6 +14,7 @@ using UnityEngine.SceneManagement;
 using System.Linq;
 #if UNITY_URP
 using UnityEngine.Rendering.Universal;
+
 #endif
 #if UNITY_HDRP
 using UnityEngine.Rendering;
@@ -109,6 +110,8 @@ namespace PlateauToolkit.Rendering.Editor
         bool m_TextureMerged;
 #endif
 
+        PlateauToolkitRenderingTileStrategy m_RenderingTileStrategy;
+
         enum Tab
         {
             LodGrouping,
@@ -157,6 +160,12 @@ namespace PlateauToolkit.Rendering.Editor
 
             Selection.selectionChanged += CancelEditMode;
             Selection.selectionChanged += CancelScalingMode;
+
+            // タイル選択UIの初期化
+            if (m_RenderingTileStrategy == null)
+            {
+                m_RenderingTileStrategy = new PlateauToolkitRenderingTileStrategy(this, m_AutoTextureProcessor, m_Grouping);
+            }
         }
 
         void OnDisable()
@@ -364,11 +373,23 @@ namespace PlateauToolkit.Rendering.Editor
                     EditorGUILayout.HelpBox("建物のテクスチャを自動的に生成します。実在する建物の見た目と異なる場合があります。", MessageType.Info);
                     EditorGUILayout.Space();
 
+                    // タイル選択UIの表示
+                    m_RenderingTileStrategy?.Draw();
+
                     EditorGUI.BeginChangeCheck();
                     if (GUILayout.Button("テクスチャ生成"))
                     {
-                        m_SelectedObjects.Clear();
-                        AutoTexture();
+                        if (m_RenderingTileStrategy?.IsTileManagerSelected == true)
+                        {
+                            // タイル用処理
+                            m_RenderingTileStrategy.AutoTexture();
+                        }
+                        else
+                        {
+                            // 通常処理
+                            m_SelectedObjects.Clear();
+                            AutoTexture();
+                        }
                     }
 
                     EditorGUILayout.Space();
@@ -1476,6 +1497,12 @@ namespace PlateauToolkit.Rendering.Editor
                     m_TextureEnhance.SaveImageParameter(ImageEditParameters.Sharpness, m_Sharpness);
                 }
             }
+        }
+
+        internal void BlockUI()
+        {
+            m_BlockUI = true;
+            Repaint();
         }
 
         internal void UnblockUI()

--- a/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingWindow.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingWindow.cs
@@ -12,6 +12,8 @@ using PlateauToolkit.Rendering.ImageProcessing;
 using UnityEditor.SceneManagement;
 using UnityEngine.SceneManagement;
 using System.Linq;
+using PLATEAU.DynamicTile;
+
 #if UNITY_URP
 using UnityEngine.Rendering.Universal;
 
@@ -164,7 +166,7 @@ namespace PlateauToolkit.Rendering.Editor
             // タイル選択UIの初期化
             if (m_RenderingTileStrategy == null)
             {
-                m_RenderingTileStrategy = new PlateauToolkitRenderingTileStrategy(this, m_AutoTextureProcessor, m_Grouping);
+                m_RenderingTileStrategy = new PlateauToolkitRenderingTileStrategy(this);
             }
         }
 
@@ -323,12 +325,19 @@ namespace PlateauToolkit.Rendering.Editor
 
                     if (GUILayout.Button("LODグループ生成"))
                     {
+
+                        string message = "シーンのオブジェクトが変更されます。実行しますか？";
+                        if (FindObjectOfType<PLATEAUTileManager>() != null)
+                        {
+                            message += "\n(動的タイルはLODグループ生成の対象に含まれません。)";
+                        }
+
                         bool isOptionSelected = EditorUtility.DisplayDialog(
-                               "LODグループ生成の確認",
-                               "シーンのオブジェクトが変更されます。実行しますか？",
-                               "はい",
-                               "いいえ"
-                           );
+                            "LODグループ生成の確認",
+                            message,
+                            "はい",
+                            "いいえ"
+                            );
 
                         if (isOptionSelected)
                         {
@@ -337,6 +346,7 @@ namespace PlateauToolkit.Rendering.Editor
 #if PLATEAU_SDK_222
                             var building = GameObject.FindObjectsOfType<GameObject>()
                                 .Where(obj => obj.GetComponent<PLATEAUCityObjectGroup>() != null
+                                        && obj.GetComponentInParent<PLATEAUTileManager>() == null //タイルは除外
                                         && (obj.name.Contains("BLD") || obj.name.Contains("bldg") || obj.name.Contains("group")))
                                 .FirstOrDefault();
                             if (building != null)
@@ -360,9 +370,9 @@ namespace PlateauToolkit.Rendering.Editor
                             }
 #else
 
-                            m_Grouping.TrySeparateMeshes();
-                            m_Grouping.GroupObjects();
-                            m_CreateLodGroup.CreateLodGroups();
+                        m_Grouping.TrySeparateMeshes();
+                        m_Grouping.GroupObjects();
+                        m_CreateLodGroup.CreateLodGroups();
 #endif
                         }
                     }
@@ -382,7 +392,7 @@ namespace PlateauToolkit.Rendering.Editor
                         if (m_RenderingTileStrategy?.IsTileManagerSelected == true)
                         {
                             // タイル用処理
-                            m_RenderingTileStrategy.AutoTexture();
+                            m_RenderingTileStrategy.CreateTexture();
                         }
                         else
                         {
@@ -967,6 +977,18 @@ namespace PlateauToolkit.Rendering.Editor
         void AutoTexture()
         {
             PlateauRenderingMeshUtilities.GetSelectedGameObjects(m_SelectedObjects);
+
+            // TileManager を親に持つオブジェクトが選択されている場合は警告を出す
+            if (m_SelectedObjects.Any(go => go.GetComponentInParent<PLATEAUTileManager>() != null))
+            {
+                string message = "動的タイルを対象とするには「調整対象の種類」を動的タイルにしてください。";
+                EditorUtility.DisplayDialog(
+                    "オブジェクト選択の確認",
+                    message,
+                    "OK"
+                    );
+                return;
+            }
 
             if (!SelectedObjectsExist())
             {

--- a/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingWindow.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingWindow.cs
@@ -112,7 +112,7 @@ namespace PlateauToolkit.Rendering.Editor
         bool m_TextureMerged;
 #endif
 
-        PlateauToolkitRenderingTileStrategy m_RenderingTileStrategy;
+        IPlateauToolkitRenderingStrategy m_RenderingStrategy;
 
         enum Tab
         {
@@ -164,9 +164,10 @@ namespace PlateauToolkit.Rendering.Editor
             Selection.selectionChanged += CancelScalingMode;
 
             // タイル選択UIの初期化
-            if (m_RenderingTileStrategy == null)
+            if (m_RenderingStrategy == null)
             {
-                m_RenderingTileStrategy = new PlateauToolkitRenderingTileStrategy(this);
+                //　現状はタイル用処理のみ実装
+                m_RenderingStrategy = new PlateauToolkitRenderingTileStrategy(this);
             }
         }
 
@@ -393,15 +394,15 @@ namespace PlateauToolkit.Rendering.Editor
                     EditorGUILayout.Space();
 
                     // タイル選択UIの表示
-                    m_RenderingTileStrategy?.Draw();
+                    m_RenderingStrategy?.DrawUIForAutoTexture();
 
                     EditorGUI.BeginChangeCheck();
                     if (GUILayout.Button("テクスチャ生成"))
                     {
-                        if (IsTileSelected())
+                        if (IsStrategyAvailable())
                         {
                             // タイル用処理
-                            m_RenderingTileStrategy.CreateTexture();
+                            m_RenderingStrategy.CreateTexture();
                         }
                         else
                         {
@@ -790,7 +791,7 @@ namespace PlateauToolkit.Rendering.Editor
                         {
                             ApplyImageOperations();
 
-                            m_RenderingTileStrategy?.DrawImageFilterSaveTileButton(m_TextureEnhance, m_ComputeShader);
+                            m_RenderingStrategy?.PostApplyImageOperations(m_TextureEnhance, m_ComputeShader);
                         }
                         EditorGUILayout.EndVertical();
                     }
@@ -975,7 +976,7 @@ namespace PlateauToolkit.Rendering.Editor
                         {
                             ApplyImageScaling();
 
-                            m_RenderingTileStrategy?.DrawImageScalingSaveTileButton(m_TextureDownscaleRatio);
+                            m_RenderingStrategy?.PostImageScaling(m_TextureDownscaleRatio);
                         }
 
                         EditorGUILayout.EndVertical();
@@ -1066,7 +1067,7 @@ namespace PlateauToolkit.Rendering.Editor
         void ApplyImageScaling()
         {
             //m_SelectedObjectIsInTile = false;
-            m_RenderingTileStrategy?.ResetConvertedObjectsInTile();
+            m_RenderingStrategy?.ResetConvertedObjects();
 
             GameObject[] selectedObjects = Selection.gameObjects;
             foreach (GameObject gameObject in selectedObjects)
@@ -1091,7 +1092,7 @@ namespace PlateauToolkit.Rendering.Editor
 
                 if (ApplyImageScalingForObject(gameObject, m_TextureDownscaleRatio))
                 {
-                    m_RenderingTileStrategy?.AddConvertedObject(gameObject);
+                    m_RenderingStrategy?.AddConvertedObject(gameObject);
                 }
             }
         }
@@ -1152,7 +1153,7 @@ namespace PlateauToolkit.Rendering.Editor
 
         void ApplyImageOperations()
         {
-            m_RenderingTileStrategy?.ResetConvertedObjectsInTile();
+            m_RenderingStrategy?.ResetConvertedObjects();
 
             GameObject[] selectedObjects = Selection.gameObjects;
             foreach (GameObject gameObject in selectedObjects)
@@ -1177,7 +1178,7 @@ namespace PlateauToolkit.Rendering.Editor
 
                 if (ApplyImageOperationsForObject(gameObject, m_TextureEnhance, m_ComputeShader))
                 {
-                    m_RenderingTileStrategy?.AddConvertedObject(gameObject);
+                    m_RenderingStrategy?.AddConvertedObject(gameObject);
                 }
             }
         }
@@ -1388,12 +1389,12 @@ namespace PlateauToolkit.Rendering.Editor
         }
 
         /// <summary>
-        /// 動的タイルが選択されているかどうか
+        /// PlateauToolkitRenderingTileStrategyの場合：動的タイルが選択されているかどうかを判別
         /// </summary>
         /// <returns></returns>
-        bool IsTileSelected()
+        bool IsStrategyAvailable()
         {
-            return m_RenderingTileStrategy?.IsTileManagerSelected == true;
+            return m_RenderingStrategy?.IsAvailable == true;
         }
 
         bool CanImageEditSelection()

--- a/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingWindow.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauToolkitRenderingWindow.cs
@@ -343,37 +343,46 @@ namespace PlateauToolkit.Rendering.Editor
                         {
                             m_BlockUI = true;
 
-#if PLATEAU_SDK_222
                             var building = GameObject.FindObjectsOfType<GameObject>()
                                 .Where(obj => obj.GetComponent<PLATEAUCityObjectGroup>() != null
                                         && obj.GetComponentInParent<PLATEAUTileManager>() == null //タイルは除外
                                         && (obj.name.Contains("BLD") || obj.name.Contains("bldg") || obj.name.Contains("group")))
                                 .FirstOrDefault();
-                            if (building != null)
+                            if (building == null)
                             {
-                                m_MeshGranularity = building.GetComponent<PLATEAUCityObjectGroup>().Granularity;
-                            }
-                            if (m_MeshGranularity == MeshGranularity.PerCityModelArea)
-                            {
-                                PLATEAUInstancedCityModel rootCityModel = PlateauRenderingBuildingUtilities.RetrieveTopmostParentWithComponent<PLATEAUInstancedCityModel>(building.transform);
-                                ConvertAsync(rootCityModel.gameObject, () =>
-                                {
-                                    m_Grouping.GroupObjects();
-                                    m_CreateLodGroup.CreateLodGroups();
-                                }).ContinueWithErrorCatch();
+                                EditorUtility.DisplayDialog(
+                                   "オブジェクトの確認",
+                                   "有効なオブジェクトが見つかりませんでした。",
+                                   "OK"
+                                   );
+                                m_BlockUI = false;
                             }
                             else
                             {
+#if PLATEAU_SDK_222
+                                m_MeshGranularity = building.GetComponent<PLATEAUCityObjectGroup>().Granularity;
+                                if (m_MeshGranularity == MeshGranularity.PerCityModelArea)
+                                {
+                                    PLATEAUInstancedCityModel rootCityModel = PlateauRenderingBuildingUtilities.RetrieveTopmostParentWithComponent<PLATEAUInstancedCityModel>(building.transform);
+                                    ConvertAsync(rootCityModel.gameObject, () =>
+                                    {
+                                        m_Grouping.GroupObjects();
+                                        m_CreateLodGroup.CreateLodGroups();
+                                    }).ContinueWithErrorCatch();
+                                }
+                                else
+                                {
+                                    m_Grouping.TrySeparateMeshes();
+                                    m_Grouping.GroupObjects();
+                                    m_CreateLodGroup.CreateLodGroups();
+                                }
+
+#else
                                 m_Grouping.TrySeparateMeshes();
                                 m_Grouping.GroupObjects();
                                 m_CreateLodGroup.CreateLodGroups();
-                            }
-#else
-
-                        m_Grouping.TrySeparateMeshes();
-                        m_Grouping.GroupObjects();
-                        m_CreateLodGroup.CreateLodGroups();
 #endif
+                            }
                         }
                     }
                     break;

--- a/PlateauToolkit.Rendering/Editor/TextureScaler.cs
+++ b/PlateauToolkit.Rendering/Editor/TextureScaler.cs
@@ -117,6 +117,7 @@ namespace PlateauToolkit.Rendering.Editor
             result.ReadPixels(new Rect(0, 0, targetX, targetY), 0, 0);
             result.Compress(true);
             result.Apply(false);
+            result.name = texture2D.name;
 
             RenderTexture.active = previous;
             current.Release();

--- a/PlateauToolkit.Rendering/Runtime/PostEffects/HalftoneURP.cs
+++ b/PlateauToolkit.Rendering/Runtime/PostEffects/HalftoneURP.cs
@@ -69,7 +69,7 @@ public class HalftoneURP : ScriptableRendererFeature
             material.SetFloat("_Range", halftoneRange);
             material.SetFloat("_UseColor", useColor ? 1.0f : 0.0f);
 
-            source = renderingData.cameraData.renderer.cameraColorTarget;
+            source = renderingData.cameraData.renderer.cameraColorTargetHandle;
             CommandBuffer cmd = CommandBufferPool.Get("HalftonePass");
 
             cmd.Blit(source, halftoneBuffer);

--- a/PlateauToolkit.Rendering/Runtime/PostEffects/NightVisionURP.cs
+++ b/PlateauToolkit.Rendering/Runtime/PostEffects/NightVisionURP.cs
@@ -64,7 +64,7 @@ public class NightVisionURP : ScriptableRendererFeature
             material.SetFloat("_Range", range);
             material.SetColor("_Color", color);
 
-            source = renderingData.cameraData.renderer.cameraColorTarget;
+            source = renderingData.cameraData.renderer.cameraColorTargetHandle;
             CommandBuffer cmd = CommandBufferPool.Get("NightVisionPass");
 
             cmd.Blit(source, nightVisonBuffer);

--- a/PlateauToolkit.Rendering/Runtime/PostEffects/TiltShiftURP.cs
+++ b/PlateauToolkit.Rendering/Runtime/PostEffects/TiltShiftURP.cs
@@ -84,7 +84,7 @@ public class TiltShiftURP : ScriptableRendererFeature
             blurMaterial.SetInt("_Samples", blurSamples);
             blurMaterial.SetFloat("_BlurStartRange", blurStartRange);
 
-            source = renderingData.cameraData.renderer.cameraColorTarget;
+            source = renderingData.cameraData.renderer.cameraColorTargetHandle;
             CommandBuffer cmd = CommandBufferPool.Get("BlurPass");
 
             cmd.Blit(source, blurBuffer);

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
@@ -69,17 +69,29 @@ namespace PlateauToolkit.Sandbox.Editor
         }
 
         /// <summary>
-        /// EditorSplineUtility.SetKnotPlacementTool()が使用できないため代替実装
+        /// spline 2.8 以降で EditorSplineUtility.SetKnotPlacementTool()が使用できないため代替実装
+        /// (Unity 2022 3以降）
+        /// 将来的に使用できなくなる可能性あり。
+        /// EditorSplineUtility.SetKnotPlacementTool();が使用できる場合はそちらを使用すること。
         /// </summary>
         void SetKnotPlacementTool()
         {
-            ToolManager.SetActiveContext<SplineToolContext>();
-
-            System.Reflection.Assembly asm = typeof(SplineToolContext).Assembly;
-            Type type = asm.GetType("UnityEditor.Splines.CreateSplineTool");
-            if (type != null)
+            try
             {
-                ToolManager.SetActiveTool(type);
+                EditorSplineUtility.SetKnotPlacementTool();
+            }
+            catch (Exception)
+            {
+                Debug.LogWarning("EditorSplineUtility.SetKnotPlacementTool() is not available. Using alternative implementation.");
+
+                ToolManager.SetActiveContext<SplineToolContext>();
+
+                System.Reflection.Assembly asm = typeof(SplineToolContext).Assembly;
+                Type type = asm.GetType("UnityEditor.Splines.CreateSplineTool");
+                if (type != null)
+                {
+                    ToolManager.SetActiveTool(type);
+                }
             }
         }
 
@@ -116,7 +128,6 @@ namespace PlateauToolkit.Sandbox.Editor
                         EditorApplication.delayCall += () =>
                         {
                             SetKnotPlacementTool();
-                            EditorSplineUtility.SetKnotPlacementTool();
                             RefreshTracksHierarchy(context);
                         };
 

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
@@ -69,7 +69,7 @@ namespace PlateauToolkit.Sandbox.Editor
         }
 
         /// <summary>
-        /// spline 2.8 以降(Unity 2022 3以降）で EditorSplineUtility.SetKnotPlacementTool()が使用できないため代替実装
+        /// Splines 2.6.0 以降(Unity 2022 3以降）で EditorSplineUtility.SetKnotPlacementTool()が使用できないため代替実装
         /// 将来的に使用できなくなる可能性あり。
         /// 将来のバージョンでEditorSplineUtility.SetKnotPlacementTool();が使用できるようになった場合はそちらを使用すること。
         /// </summary>

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
@@ -68,6 +68,20 @@ namespace PlateauToolkit.Sandbox.Editor
             ToolManager.activeToolChanged += OnActiveToolChanged;
         }
 
+        /// <summary>
+        /// EditorSplineUtility.SetKnotPlacementTool()が使用できないため代替実装
+        /// </summary>
+        void SetKnotPlacementTool()
+        {
+            ToolManager.SetActiveContext<SplineToolContext>();
+
+            System.Reflection.Assembly asm = typeof(SplineToolContext).Assembly;
+            Type type = asm.GetType("UnityEditor.Splines.CreateSplineTool");
+            if (type != null)
+            {
+                ToolManager.SetActiveTool(type);
+            }
+        }
 
         public void OnGUI(PlateauSandboxContext context, EditorWindow window)
         {
@@ -101,6 +115,7 @@ namespace PlateauToolkit.Sandbox.Editor
                         ActiveEditorTracker.sharedTracker.RebuildIfNecessary();
                         EditorApplication.delayCall += () =>
                         {
+                            SetKnotPlacementTool();
                             EditorSplineUtility.SetKnotPlacementTool();
                             RefreshTracksHierarchy(context);
                         };

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
@@ -71,7 +71,7 @@ namespace PlateauToolkit.Sandbox.Editor
         /// <summary>
         /// spline 2.8 以降(Unity 2022 3以降）で EditorSplineUtility.SetKnotPlacementTool()が使用できないため代替実装
         /// 将来的に使用できなくなる可能性あり。
-        /// EditorSplineUtility.SetKnotPlacementTool();が使用できる場合はそちらを使用すること。
+        /// 将来のバージョンでEditorSplineUtility.SetKnotPlacementTool();が使用できるようになった場合はそちらを使用すること。
         /// </summary>
         void SetKnotPlacementTool()
         {

--- a/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
+++ b/PlateauToolkit.Sandbox/Editor/PlateauSandboxWindowTrackView.cs
@@ -69,8 +69,7 @@ namespace PlateauToolkit.Sandbox.Editor
         }
 
         /// <summary>
-        /// spline 2.8 以降で EditorSplineUtility.SetKnotPlacementTool()が使用できないため代替実装
-        /// (Unity 2022 3以降）
+        /// spline 2.8 以降(Unity 2022 3以降）で EditorSplineUtility.SetKnotPlacementTool()が使用できないため代替実装
         /// 将来的に使用できなくなる可能性あり。
         /// EditorSplineUtility.SetKnotPlacementTool();が使用できる場合はそちらを使用すること。
         /// </summary>
@@ -85,7 +84,6 @@ namespace PlateauToolkit.Sandbox.Editor
                 Debug.LogWarning("EditorSplineUtility.SetKnotPlacementTool() is not available. Using alternative implementation.");
 
                 ToolManager.SetActiveContext<SplineToolContext>();
-
                 System.Reflection.Assembly asm = typeof(SplineToolContext).Assembly;
                 Type type = asm.GetType("UnityEditor.Splines.CreateSplineTool");
                 if (type != null)


### PR DESCRIPTION
関連リンク
https://synesthesias.atlassian.net/wiki/spaces/PS/pages/1178632221
https://synesthesias.atlassian.net/browse/CPSDK25-46

sdkプルリク
https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/pull/552

Rendering Tool kit のTile対応
Unity 6への仮対応 (Splineツールを無理やり起動）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

* **新機能**
  * 動的タイルのレンダリング戦略を追加しました。テクスチャ自動生成やタイル単位の処理が可能になりました。

* **改善**
  * LODグループ化ワークフローを整理し、処理の安定性とキャンセル反映を向上しました。
  * 建物判定ロジックを拡張し、より多くのケースを正しく検出します。
  * リサイズ後のテクスチャ名を保持するようになりました。
  * ポストエフェクト処理（ハーフトーン／ナイトビジョン／チルトシフト）を最適化しました。
  * エディタ内のツール切替でフォールバック処理を追加し互換性を改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->