### PR TITLE
SandboxToolkitの交通シミュレーションのタイル対応

### DIFF
--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/PlateauSandboxTrafficManager.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/PlateauSandboxTrafficManager.cs
@@ -124,9 +124,15 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
             // Tileの場合、Load時にDemをGroundに設定
             if (tile.Package == PLATEAU.Dataset.PredefinedCityModelPackage.Relief && tile.LoadedObject != null)
             {
+                int groundLayer = LayerMask.NameToLayer(PlateauSandboxTrafficManagerConstants.LAYER_MASK_GROUND);
+                if (groundLayer == -1)
+                {
+                    Debug.LogWarning($"Layer '{PlateauSandboxTrafficManagerConstants.LAYER_MASK_GROUND}' does not exist.");
+                    return;
+                }
                 foreach (Transform child in tile.LoadedObject.transform.GetAllChildrenWithComponent<PLATEAUCityObjectGroup>())
                 {
-                    child.gameObject.layer = LayerMask.NameToLayer(PlateauSandboxTrafficManagerConstants.LAYER_MASK_GROUND);
+                    child.gameObject.layer = groundLayer;
                 }
             }
         }

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/PlateauSandboxTrafficManager.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/PlateauSandboxTrafficManager.cs
@@ -98,7 +98,7 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
         {
             // Tile用処理(読込後にDemをGroundに設定するための処理）
             // 重要性は低いので不要なら削除しても大きな問題はないはずだが念のため
-            m_TileManager = GameObject.FindObjectOfType<PLATEAUTileManager>();
+            m_TileManager = GameObject.FindFirstObjectByType<PLATEAUTileManager>();
             if (m_TileManager != null)
             {
                 m_TileManager.onTileInstantiatedAction -= OnTileLoaded;

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/PlateauSandboxTrafficManager.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/PlateauSandboxTrafficManager.cs
@@ -5,6 +5,9 @@ using PLATEAU.RoadNetwork.Structure;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using PLATEAU.DynamicTile;
+using PLATEAU.Util;
+using PLATEAU.CityInfo;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -46,6 +49,11 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
 
         RoadNetworkDataGetter m_RoadNetworkGetter;
 
+        /// <summary>
+        /// Tile処理に使用
+        /// </summary>
+        PLATEAUTileManager m_TileManager = null;
+
         public TrafficManager SimTrafficManager
         {
             get
@@ -84,6 +92,43 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
         {
             int numRoads = RnGetter.GetRoadBases().OfType<RnDataRoad>().Count();
             return (int)Mathf.Min(numRoads / 2, PlateauSandboxTrafficManagerConstants.NUM_MAX_VEHICLES); // 交差点以外の道路数の半分 or 最大車輛数
+        }
+
+        void Start()
+        {
+            // Tile用処理(読込後にDemをGroundに設定するための処理）
+            // 重要性は低いので不要なら削除しても大きな問題はないはずだが念のため
+            m_TileManager = GameObject.FindObjectOfType<PLATEAUTileManager>();
+            if (m_TileManager != null)
+            {
+                m_TileManager.onTileInstantiatedAction -= OnTileLoaded;
+                m_TileManager.onTileInstantiatedAction += OnTileLoaded;
+            }
+        }
+
+        void OnDestroy()
+        {
+            if (m_TileManager != null)
+            {
+                m_TileManager.onTileInstantiatedAction -= OnTileLoaded;
+            }
+        }
+
+        /// <summary>
+        /// TileManagerが存在する場合、Tileの読込を監視しLayerを設定
+        /// (AddressablesのLayerは、Asset読込後に設定する必要があるため)
+        /// </summary>
+        /// <param name="tile"></param>
+        void OnTileLoaded(PLATEAUDynamicTile tile)
+        {
+            // Tileの場合、Load時にDemをGroundに設定
+            if (tile.Package == PLATEAU.Dataset.PredefinedCityModelPackage.Relief && tile.LoadedObject != null)
+            {
+                foreach (Transform child in tile.LoadedObject.transform.GetAllChildrenWithComponent<PLATEAUCityObjectGroup>())
+                {
+                    child.gameObject.layer = LayerMask.NameToLayer(PlateauSandboxTrafficManagerConstants.LAYER_MASK_GROUND);
+                }
+            }
         }
 
         public void CreateSimulator(List<GameObject> prefabs)

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadNetworkLaneConverter.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadNetworkLaneConverter.cs
@@ -79,13 +79,10 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
             {
                 foreach (RnCityObjectGroupKey key in keys)
                 {
-                    if (key != null)
+                    Transform trans = m_RoadTransformGetter.GetRoadTransform(key);
+                    if (trans != null)
                     {
-                        Transform trans = m_RoadTransformGetter.GetRoadTransform(key.GmlId);
-                        if (trans != null)
-                        {
-                            trans.gameObject.layer = LayerMask.NameToLayer(PlateauSandboxTrafficManagerConstants.LAYER_MASK_GROUND);
-                        }
+                        trans.gameObject.layer = LayerMask.NameToLayer(PlateauSandboxTrafficManagerConstants.LAYER_MASK_GROUND);
                     }
                 }
             }

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadNetworkLaneConverter.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadNetworkLaneConverter.cs
@@ -1,6 +1,7 @@
 ﻿using AWSIM;
 using AWSIM.TrafficSimulation;
 using PLATEAU.CityInfo;
+using PLATEAU.RoadNetwork;
 using PLATEAU.RoadNetwork.Data;
 using PLATEAU.RoadNetwork.Structure;
 using System.Collections.Generic;
@@ -18,6 +19,8 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
     {
 
         public static readonly bool SHOW_DEBUG_INFO = false;
+
+        RoadTransformGetter m_RoadTransformGetter;
 
         //temporarily keeps Lane information as RoadNetwork data
         public struct LaneConvertInfo
@@ -70,15 +73,19 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
             return outPoints;
         }
 
-        void SetAsGroundLayer(List<PLATEAUCityObjectGroup> cityObjs)
+        void SetAsGroundLayer(List<RnCityObjectGroupKey> keys)
         {
-            if (cityObjs?.Count > 0)
+            if (keys?.Count > 0)
             {
-                foreach (var item in cityObjs)
+                foreach (RnCityObjectGroupKey key in keys)
                 {
-                    if (item != null)
+                    if (key != null)
                     {
-                        item.gameObject.layer = LayerMask.NameToLayer(PlateauSandboxTrafficManagerConstants.LAYER_MASK_GROUND);
+                        Transform trans = m_RoadTransformGetter.GetRoadTransform(key.GmlId);
+                        if (trans != null)
+                        {
+                            trans.gameObject.layer = LayerMask.NameToLayer(PlateauSandboxTrafficManagerConstants.LAYER_MASK_GROUND);
+                        }
                     }
                 }
             }
@@ -101,7 +108,8 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
             var intersectionName = $"TrafficIntersection_{intersection.GetId(getter)}";
             var intersectionGameObject = new GameObject(intersectionName, typeof(TrafficIntersection));
 
-            if (trafficLightController.GetParentRoad(getter).TargetTrans.FirstOrDefault().TryGetComponent<MeshRenderer>(out MeshRenderer renderer))
+            Transform firstTrans = m_RoadTransformGetter.GetRoadTransform(trafficLightController.GetParentRoad(getter).TargetGroupKeys.FirstOrDefault().GmlId);
+            if (firstTrans != null && firstTrans.TryGetComponent<MeshRenderer>(out MeshRenderer renderer))
             {
                 intersectionGameObject.transform.position = renderer.bounds.center;
                 var collider = intersectionGameObject.GetComponent<BoxCollider>();
@@ -209,6 +217,8 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
 
         public List<TrafficLane> Create(RoadNetworkDataGetter getter, Transform parent)
         {
+            m_RoadTransformGetter = new RoadTransformGetter();
+
             var laneParent = GameObject.Find(PlateauSandboxTrafficManagerConstants.TRAFFIC_LANE_ROOT_NAME);
             if (laneParent == null)
             {
@@ -246,7 +256,7 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
                 {
                     RnDataRoad road = (RnDataRoad)rb;
 
-                    SetAsGroundLayer(road.TargetTrans);
+                    SetAsGroundLayer(road.TargetGroupKeys);
 
                     List<RnDataLane> lanes = road.GetMainLanes(getter);
 
@@ -331,7 +341,8 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
                         continue;
                     }
 
-                    SetAsGroundLayer(intersection.TargetTrans);
+                    SetAsGroundLayer(intersection.TargetGroupKeys);
+
                     CreateTrafficIntersection(intersection, getter, intersectionParent.transform);
 
                     var tracks = intersection.Tracks;

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadNetworkLaneConverter.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadNetworkLaneConverter.cs
@@ -108,7 +108,7 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
             var intersectionName = $"TrafficIntersection_{intersection.GetId(getter)}";
             var intersectionGameObject = new GameObject(intersectionName, typeof(TrafficIntersection));
 
-            Transform firstTrans = m_RoadTransformGetter.GetRoadTransform(trafficLightController.GetParentRoad(getter).TargetGroupKeys.FirstOrDefault().GmlId);
+            Transform firstTrans = m_RoadTransformGetter.GetRoadTransform(trafficLightController.GetParentRoad(getter).TargetGroupKeys.FirstOrDefault());
             if (firstTrans != null && firstTrans.TryGetComponent<MeshRenderer>(out MeshRenderer renderer))
             {
                 intersectionGameObject.transform.position = renderer.bounds.center;

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
@@ -1,9 +1,13 @@
 ﻿
 using PLATEAU.RoadAdjust.RoadNetworkToMesh;
+using PLATEAU.RoadNetwork;
 using UnityEngine;
 
 namespace PlateauToolkit.Sandbox.RoadNetwork
 {
+    /// <summary>
+    /// 道路ネットワークのデータに紐づくUnityのTransform等の情報を取得するためのクラス
+    /// </summary>
     public class RoadTransformGetter
     {
         const string k_ROAD_PREFIX = "Road-"; //PLATEAUReproducedRoad名のPrefix
@@ -28,6 +32,21 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
             string roadName = k_ROAD_PREFIX + gmlId;
             // 取得できないケースもあるが無視
             return m_ReproducedRoadRoot.Find(roadName);
+        }
+
+        /// <summary>
+        /// RnCityObjectGroupKeyからTransforomを取得
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public Transform GetRoadTransform(RnCityObjectGroupKey key)
+        {
+            if (key == null)
+            {
+                return null;
+            }
+
+            return GetRoadTransform(key.GmlId);
         }
     }
 }

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
@@ -12,26 +12,24 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
     {
         const string k_ROAD_PREFIX = "Road-"; //PLATEAUReproducedRoad名のPrefix
 
-        readonly Transform m_ReproducedRoadRoot;
-        public Transform ReproducedRoad => m_ReproducedRoadRoot;
+        Transform m_ReproducedRoadRoot;
+        public Transform ReproducedRoad => GetReproducedRoadRoot();
 
         public RoadTransformGetter()
         {
-            // 最初に見つかったPLATEAUReproducedRoadの親を取得する(ReproducedRoadのParentはシーンに1つと想定）
-            PLATEAUReproducedRoad found = Object.FindFirstObjectByType<PLATEAUReproducedRoad>();
-            m_ReproducedRoadRoot = found?.transform.parent;
+            GetReproducedRoadRoot();
         }
 
         public Transform GetRoadTransform(string gmlId)
         {
-            if (m_ReproducedRoadRoot == null)
+            if (GetReproducedRoadRoot() == null)
             {
                 return null;
             }
 
             string roadName = k_ROAD_PREFIX + gmlId;
             // 取得できないケースもあるが無視
-            return m_ReproducedRoadRoot.Find(roadName);
+            return GetReproducedRoadRoot().Find(roadName);
         }
 
         /// <summary>
@@ -47,6 +45,19 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
             }
 
             return GetRoadTransform(key.GmlId);
+        }
+
+        Transform GetReproducedRoadRoot()
+        {
+            if (m_ReproducedRoadRoot != null)
+            {
+                return m_ReproducedRoadRoot;
+            }
+
+            // 最初に見つかったPLATEAUReproducedRoadの親を取得する(ReproducedRoadのParentはシーンに1つと想定）
+            PLATEAUReproducedRoad found = Object.FindFirstObjectByType<PLATEAUReproducedRoad>();
+            m_ReproducedRoadRoot = found?.transform.parent;
+            return m_ReproducedRoadRoot;
         }
     }
 }

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
@@ -8,17 +8,14 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
     {
         const string k_ROAD_PREFIX = "Road-"; //PLATEAUReproducedRoad名のPrefix
 
-        Transform m_ReproducedRoadRoot;
+        readonly Transform m_ReproducedRoadRoot;
         public Transform ReproducedRoad => m_ReproducedRoadRoot;
 
         public RoadTransformGetter()
         {
             // 最初に見つかったPLATEAUReproducedRoadの親を取得する(ReproducedRoadのParentはシーンに1つと想定）
             PLATEAUReproducedRoad found = Object.FindFirstObjectByType<PLATEAUReproducedRoad>();
-            if (found != null)
-            {
-                m_ReproducedRoadRoot = found.transform.parent;
-            }
+            m_ReproducedRoadRoot = found?.transform.parent;
         }
 
         public Transform GetRoadTransform(string gmlId)
@@ -29,15 +26,8 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
             }
 
             string roadName = k_ROAD_PREFIX + gmlId;
-            Transform roadTransform = m_ReproducedRoadRoot.Find(roadName);
-
-            if (roadTransform == null)
-            {
-                //取得できないケースもあるが無視
-                return null;
-            }
-
-            return roadTransform;
+            // 取得できないケースもあるが無視
+            return m_ReproducedRoadRoot.Find(roadName);
         }
     }
 }

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
@@ -41,7 +41,7 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
         /// <returns></returns>
         public Transform GetRoadTransform(RnCityObjectGroupKey key)
         {
-            if (key == null)
+            if (!key.IsValid)
             {
                 return null;
             }

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
@@ -1,0 +1,43 @@
+﻿
+using PLATEAU.RoadAdjust.RoadNetworkToMesh;
+using UnityEngine;
+
+namespace PlateauToolkit.Sandbox.RoadNetwork
+{
+    public class RoadTransformGetter
+    {
+        const string k_ROAD_PREFIX = "Road-"; //PLATEAUReproducedRoad名のPrefix
+
+        Transform m_ReproducedRoadRoot;
+        public Transform ReproducedRoad => m_ReproducedRoadRoot;
+
+        public RoadTransformGetter()
+        {
+            // 最初に見つかったPLATEAUReproducedRoadの親を取得する(ReproducedRoadのParentはシーンに1つと想定）
+            PLATEAUReproducedRoad found = GameObject.FindObjectOfType<PLATEAUReproducedRoad>();
+            if (found != null)
+            {
+                m_ReproducedRoadRoot = found.transform.parent;
+            }
+        }
+
+        public Transform GetRoadTransform(string gmlId)
+        {
+            if (m_ReproducedRoadRoot == null)
+            {
+                return null;
+            }
+
+            string roadName = k_ROAD_PREFIX + gmlId;
+            Transform roadTransform = m_ReproducedRoadRoot.Find(roadName);
+
+            if (roadTransform == null)
+            {
+                //取得できないケースもあるが無視
+                return null;
+            }
+
+            return roadTransform;
+        }
+    }
+}

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
@@ -13,23 +13,24 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
         const string k_ROAD_PREFIX = "Road-"; //PLATEAUReproducedRoad名のPrefix
 
         Transform m_ReproducedRoadRoot;
-        public Transform ReproducedRoad => GetReproducedRoadRoot();
+        public Transform ReproducedRoadRoot => TryGetReproducedRoadRoot();
 
         public RoadTransformGetter()
         {
-            GetReproducedRoadRoot();
+            // 初期化
+            TryGetReproducedRoadRoot();
         }
 
         public Transform GetRoadTransform(string gmlId)
         {
-            if (GetReproducedRoadRoot() == null)
+            if (TryGetReproducedRoadRoot() == null)
             {
                 return null;
             }
 
             string roadName = k_ROAD_PREFIX + gmlId;
             // 取得できないケースもあるが無視
-            return GetReproducedRoadRoot().Find(roadName);
+            return m_ReproducedRoadRoot.Find(roadName);
         }
 
         /// <summary>
@@ -47,7 +48,11 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
             return GetRoadTransform(key.GmlId);
         }
 
-        Transform GetReproducedRoadRoot()
+        /// <summary>
+        /// ReproducedRoadのTransformを取得しm_ReproducedRoadRootに設定
+        /// </summary>
+        /// <returns></returns>
+        Transform TryGetReproducedRoadRoot()
         {
             if (m_ReproducedRoadRoot != null)
             {

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
@@ -14,7 +14,7 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
         public RoadTransformGetter()
         {
             // 最初に見つかったPLATEAUReproducedRoadの親を取得する(ReproducedRoadのParentはシーンに1つと想定）
-            PLATEAUReproducedRoad found = GameObject.FindObjectOfType<PLATEAUReproducedRoad>();
+            PLATEAUReproducedRoad found = Object.FindFirstObjectByType<PLATEAUReproducedRoad>();
             if (found != null)
             {
                 m_ReproducedRoadRoot = found.transform.parent;

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs
@@ -12,18 +12,19 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
     {
         const string k_ROAD_PREFIX = "Road-"; //PLATEAUReproducedRoad名のPrefix
 
-        Transform m_ReproducedRoadRoot;
-        public Transform ReproducedRoadRoot => TryGetReproducedRoadRoot();
+        readonly Transform m_ReproducedRoadRoot;
+        public Transform ReproducedRoadRoot => m_ReproducedRoadRoot;
 
         public RoadTransformGetter()
         {
-            // 初期化
-            TryGetReproducedRoadRoot();
+            // 最初に見つかったPLATEAUReproducedRoadの親を取得する(ReproducedRoadのParentはシーンに1つと想定）
+            PLATEAUReproducedRoad found = Object.FindFirstObjectByType<PLATEAUReproducedRoad>();
+            m_ReproducedRoadRoot = found?.transform.parent;
         }
 
         public Transform GetRoadTransform(string gmlId)
         {
-            if (TryGetReproducedRoadRoot() == null)
+            if (m_ReproducedRoadRoot == null)
             {
                 return null;
             }
@@ -46,23 +47,6 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
             }
 
             return GetRoadTransform(key.GmlId);
-        }
-
-        /// <summary>
-        /// ReproducedRoadのTransformを取得しm_ReproducedRoadRootに設定
-        /// </summary>
-        /// <returns></returns>
-        Transform TryGetReproducedRoadRoot()
-        {
-            if (m_ReproducedRoadRoot != null)
-            {
-                return m_ReproducedRoadRoot;
-            }
-
-            // 最初に見つかったPLATEAUReproducedRoadの親を取得する(ReproducedRoadのParentはシーンに1つと想定）
-            PLATEAUReproducedRoad found = Object.FindFirstObjectByType<PLATEAUReproducedRoad>();
-            m_ReproducedRoadRoot = found?.transform.parent;
-            return m_ReproducedRoadRoot;
         }
     }
 }

--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs.meta
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/RoadTransformGetter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74466a5230b98d54dae44e50e349659a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
https://synesthesias.atlassian.net/browse/CPSDK25-244
https://synesthesias.atlassian.net/wiki/spaces/PS/pages/1481408549/SandboxToolkit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * シーン内の道路配置を探索・参照する仕組みを追加し、道路関連の位置決めと参照が可能になりました
* **改善**
  * タイル読み込み時に特定の地形種別へ自動で地面レイヤーを適用し表示の整合性を向上しました
  * 道路グループ単位での解決精度を高め、交差点や車線の配置精度を改善しました
* **バグ修正**
  * タイルイベントの購読解除を確実化し安定性とリソース管理を改善しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds DEM tile ground-layering on load and switches road/intersection transform lookup to key-based resolution via RoadTransformGetter.
> 
> - **Tile handling**
>   - Subscribe to `PLATEAUTileManager.onTileInstantiatedAction` in `PlateauSandboxTrafficManager` to set DEM (`Relief`) tile objects' layer to `Ground`; unsubscribe on destroy.
> - **Road/Intersection transform resolution**
>   - Introduce `RoadTransformGetter` to resolve Unity `Transform` from `RnCityObjectGroupKey`/`gmlId` under `PLATEAUReproducedRoad` root.
>   - Replace direct `TargetTrans` usage with `TargetGroupKeys` across `RoadNetworkLaneConverter`:
>     - Set ground layer via resolved transforms.
>     - Intersection placement derives bounds from the resolved road `MeshRenderer`.
>   - Initialize `RoadTransformGetter` within `RoadNetworkLaneConverter.Create()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09bbef0ab4636d6e3a7320b9925cbb3e2b7b1b1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->