### PR TITLE
Feature/tile zl9 triplanar

### DIFF
--- a/PlateauToolkit.Rendering/Editor/AutoTexturing.cs
+++ b/PlateauToolkit.Rendering/Editor/AutoTexturing.cs
@@ -279,6 +279,12 @@ namespace PlateauToolkit.Rendering.Editor
         }
         void ProcessLOD1(GameObject go, MeshRenderer meshRenderer, MeshFilter meshFilter)
         {
+            if (IsTileZl9Lod1(meshRenderer?.sharedMaterial))
+            {
+                ProcessTileZl9Lod1(go, meshRenderer, meshFilter);
+                return;
+            }
+
             Undo.RecordObject(meshRenderer, "Optimize Mesh");
             Undo.RecordObject(meshFilter, "Optimize Mesh");
 
@@ -352,6 +358,19 @@ namespace PlateauToolkit.Rendering.Editor
 
             PlateauRenderingBuildingUtilities.PlaceObstacleLightsOnBuildingCorners(go);
             PlateauRenderingBuildingUtilities.CreatePlaneUnderBuilding(go);
+        }
+
+        /// <summary>
+        /// Tile ZoomLevel 9 Lod1 Materialかどうかの判定 (PLATEAULod1TriplanarShaderを利用しているか)
+        /// </summary>
+        /// <param name="material"></param>
+        /// <returns></returns>
+        bool IsTileZl9Lod1(Material material)
+        {
+            if (material == null || material.shader == null)
+                return false;
+            string shaderName = material.shader.name;
+            return shaderName.Contains("Lod1Triplanar"); // Shader Graphs/PLATEAULod1TriplanarShader or Weather/Building_Lod1Triplanar_URP or Weather/Building_Lod1Triplanar_HDRP
         }
 
         /// <summary>

--- a/PlateauToolkit.Rendering/Editor/AutoTexturing.cs
+++ b/PlateauToolkit.Rendering/Editor/AutoTexturing.cs
@@ -279,6 +279,8 @@ namespace PlateauToolkit.Rendering.Editor
         }
         void ProcessLOD1(GameObject go, MeshRenderer meshRenderer, MeshFilter meshFilter)
         {
+            // ZoomLevel 9 Lod1のマテリアルを使用している場合は専用の処理を行う
+            // 主要地物単位の場合、Materialは１つのはずなので、sharedMaterialで判定する
             if (IsTileZl9Lod1(meshRenderer?.sharedMaterial))
             {
                 ProcessTileZl9Lod1(go, meshRenderer, meshFilter);
@@ -375,7 +377,6 @@ namespace PlateauToolkit.Rendering.Editor
 
         /// <summary>
         /// Tile ZoomLevel 9 Lod1 Material用処理 (PLATEAULod1TriplanarShader)
-        /// Sample でのみ利用
         /// </summary>
         /// <param name="go"></param>
         /// <param name="meshRenderer"></param>

--- a/PlateauToolkit.Rendering/Editor/PlateauRenderingBuildingUtilities.cs
+++ b/PlateauToolkit.Rendering/Editor/PlateauRenderingBuildingUtilities.cs
@@ -548,8 +548,7 @@ namespace PlateauToolkit.Rendering.Editor
 
         /// <summary>
         /// Tile ZoomLevel 9 Lod1 Materialの差替え
-        /// Sampleでのみ利用
-        /// HDRP非対応
+        /// PLATEAULod1TriplanarShader => Building_Lod1Triplanar_URP or Building_Lod1Triplanar_HDRP
         /// </summary>
         /// <param name="obj"></param>
         public static void ChangeTileZL9LOD1BuildingShader(GameObject obj)
@@ -632,15 +631,6 @@ namespace PlateauToolkit.Rendering.Editor
                         {
                             material.SetFloat("_BaseMapOpacity", 0.95f);
                         }
-
-                        if (material.HasProperty("_BaseMap"))
-                        {
-                            if (material.HasProperty("_RightTexture"))
-                            {
-                                material.SetTexture("_BaseMap", material.GetTexture("_RightTexture"));
-                            }
-                        }
-
 #if UNITY_URP
                         BaseShaderGUI.SetMaterialKeywords(material);
 #endif

--- a/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_HDRP.shadergraph
+++ b/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_HDRP.shadergraph
@@ -1338,6 +1338,21 @@
         },
         {
             "m_Id": "279b67d8be634c6ca20e55214acb289b"
+        },
+        {
+            "m_Id": "756aebfe75b147ab8197b80420214b1c"
+        },
+        {
+            "m_Id": "5f583581e0694590b33394c8881d1b4d"
+        },
+        {
+            "m_Id": "c3ae1150e6b2447cb50602428069d8b1"
+        },
+        {
+            "m_Id": "9109fb2b11314fd7a19f02bc443ecf74"
+        },
+        {
+            "m_Id": "b286c09f69994709ae16892059d50507"
         }
     ],
     "m_GroupDatas": [
@@ -7207,7 +7222,17 @@
             "x": 2906.0,
             "y": 340.0
         },
-        "m_Blocks": []
+        "m_Blocks": [
+            {
+                "m_Id": "756aebfe75b147ab8197b80420214b1c"
+            },
+            {
+                "m_Id": "5f583581e0694590b33394c8881d1b4d"
+            },
+            {
+                "m_Id": "c3ae1150e6b2447cb50602428069d8b1"
+            }
+        ]
     },
     "m_FragmentContext": {
         "m_Position": {
@@ -7235,6 +7260,12 @@
             },
             {
                 "m_Id": "b56ffae59aef491d99d39fa605c53a15"
+            },
+            {
+                "m_Id": "9109fb2b11314fd7a19f02bc443ecf74"
+            },
+            {
+                "m_Id": "b286c09f69994709ae16892059d50507"
             }
         ]
     },
@@ -12310,6 +12341,30 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PositionMaterialSlot",
+    "m_ObjectId": "1dfb1ccc34f04823b2188ea323ab9b98",
+    "m_Id": 0,
+    "m_DisplayName": "Position",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Position",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector2ShaderProperty",
     "m_ObjectId": "1e0161441d2b4756b56854b4ea9ac065",
@@ -17059,6 +17114,22 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "3ca527df85814dfea397a874ca81c11d",
+    "m_Id": 0,
+    "m_DisplayName": "Metallic",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Metallic",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "3cb3ea6dc81e4394b54ac839dac31ee2",
     "m_Id": 0,
@@ -21505,6 +21576,22 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "58dacff7b50a4c73b4b36ebbffef38f1",
+    "m_Id": 0,
+    "m_DisplayName": "Alpha Clip Threshold",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "AlphaClipThreshold",
+    "m_StageCapability": 2,
+    "m_Value": 0.5,
+    "m_DefaultValue": 0.5,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "58eefbf0688d4050b1ef7b419cb6e06c",
     "m_Id": 2,
@@ -22663,6 +22750,40 @@
     },
     "m_Width": 208.0,
     "m_Height": 208.0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "5f583581e0694590b33394c8881d1b4d",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Tangent",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "74df579e74c44786ae6a551b4a87f304"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Tangent"
 }
 
 {
@@ -24179,6 +24300,15 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalLitSubTarget",
+    "m_ObjectId": "6902cce589024d00a05b3ee5a3d364c7",
+    "m_WorkflowMode": 1,
+    "m_NormalDropOffSpace": 0,
+    "m_ClearCoat": false
 }
 
 {
@@ -25770,6 +25900,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.TangentMaterialSlot",
+    "m_ObjectId": "74df579e74c44786ae6a551b4a87f304",
+    "m_Id": 0,
+    "m_DisplayName": "Tangent",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Tangent",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "753bce57daf9448aa8cc168f57c3f2d0",
     "m_Id": 1466395117,
@@ -25807,6 +25961,40 @@
         "w": 0.0
     },
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "756aebfe75b147ab8197b80420214b1c",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Normal",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "f12eb997af094bbc8d20804fec8f91c6"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Normal"
 }
 
 {
@@ -30846,6 +31034,40 @@
     "m_Property": {
         "m_Id": "70d3c3d92c2a46f0a90c8ce6d51ade25"
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "9109fb2b11314fd7a19f02bc443ecf74",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Metallic",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "3ca527df85814dfea397a874ca81c11d"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Metallic"
 }
 
 {
@@ -36324,6 +36546,40 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "b286c09f69994709ae16892059d50507",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.AlphaClipThreshold",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "58dacff7b50a4c73b4b36ebbffef38f1"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.AlphaClipThreshold"
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "b2aec8aa482d4c51b433ee33ae59e1bd",
     "m_Id": 0,
@@ -39924,6 +40180,40 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "c3ae1150e6b2447cb50602428069d8b1",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Position",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "1dfb1ccc34f04823b2188ea323ab9b98"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Position"
 }
 
 {
@@ -47951,6 +48241,30 @@
         "z": 0.0
     },
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "f12eb997af094bbc8d20804fec8f91c6",
+    "m_Id": 0,
+    "m_DisplayName": "Normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Normal",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
 }
 
 {

--- a/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_HDRP.shadergraph
+++ b/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_HDRP.shadergraph
@@ -4,6 +4,9 @@
     "m_ObjectId": "0717bbe20a94494da7d0b82d065893c9",
     "m_Properties": [
         {
+            "m_Id": "3496c0de54fb4afabcc6a6a4cd32d5ca"
+        },
+        {
             "m_Id": "a2a8a714e6d843c4ae8d0888b912da24"
         },
         {
@@ -360,9 +363,6 @@
         },
         {
             "m_Id": "5271bfc300d4459d93a3bfd575417044"
-        },
-        {
-            "m_Id": "8ec08d1ee7e5412ba21797d18d85a3f4"
         },
         {
             "m_Id": "346a926dd8ab426b8eedc65ab050cd45"
@@ -1335,6 +1335,9 @@
         },
         {
             "m_Id": "7d6b6f1d824243d589e4aa47ba42fa18"
+        },
+        {
+            "m_Id": "279b67d8be634c6ca20e55214acb289b"
         }
     ],
     "m_GroupDatas": [
@@ -2296,6 +2299,20 @@
                     "m_Id": "17193ff3f51b403885610b4f867d1612"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "279b67d8be634c6ca20e55214acb289b"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "5271bfc300d4459d93a3bfd575417044"
+                },
+                "m_SlotId": 1341158853
             }
         },
         {
@@ -4480,20 +4497,6 @@
                     "m_Id": "8146d91fb3a1494c89ad02dc99050b78"
                 },
                 "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "8ec08d1ee7e5412ba21797d18d85a3f4"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "5271bfc300d4459d93a3bfd575417044"
-                },
-                "m_SlotId": 1341158853
             }
         },
         {
@@ -13856,6 +13859,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "279b67d8be634c6ca20e55214acb289b",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -3086.0,
+            "y": 3163.0,
+            "width": 135.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "f79940f5825244d3af739a78c2a14b13"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "3496c0de54fb4afabcc6a6a4cd32d5ca"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "28476b795f78453bb1b840298ef33110",
     "m_Id": 2,
@@ -15857,6 +15896,50 @@
 }
 
 {
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "3496c0de54fb4afabcc6a6a4cd32d5ca",
+    "m_Guid": {
+        "m_GuidSerialized": "37bdced4-b27f-4933-b4b7-fb201df47be4"
+    },
+    "promotedFromAssetID": "",
+    "promotedFromCategoryName": "",
+    "promotedOrdering": -1,
+    "m_Name": "WindowTile",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "WindowTile",
+    "m_DefaultReferenceName": "_WindowTile",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_PerRendererData": false,
+    "m_customAttributes": [],
+    "m_Value": 0.20000000298023225,
+    "m_FloatType": 0,
+    "m_LiteralFloatMode": false,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    },
+    "m_SliderType": 0,
+    "m_SliderPower": 3.0,
+    "m_EnumType": 0,
+    "m_CSharpEnumString": "",
+    "m_EnumNames": [
+        "Default"
+    ],
+    "m_EnumValues": [
+        0
+    ]
+}
+
+{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "34e21715e31743f98b80aceda5b7b00b",
@@ -15935,6 +16018,9 @@
         },
         {
             "m_Id": "36e132d8adbe43bfb2803632ab726ded"
+        },
+        {
+            "m_Id": "d77aab930a714b9699447f50d86ac852"
         }
     ]
 }
@@ -18172,7 +18258,7 @@
             "m_Id": "23194ec4875e4b928e423090477f1bdf"
         },
         {
-            "m_Id": "d77aab930a714b9699447f50d86ac852"
+            "m_Id": "3496c0de54fb4afabcc6a6a4cd32d5ca"
         },
         {
             "m_Id": "5451c5a8909d41f9b8c43242bc986824"
@@ -30398,42 +30484,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "8ec08d1ee7e5412ba21797d18d85a3f4",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -3048.6669921875,
-            "y": 3178.666748046875,
-            "width": 94.66650390625,
-            "height": 36.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "afc45309dbd34d028d2434ae0796ee42"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "d77aab930a714b9699447f50d86ac852"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "8f1ee701986142078b35800b1788beee",
     "m_Id": 1,
@@ -35787,22 +35837,6 @@
         "z": 0.0,
         "w": 0.0
     },
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "afc45309dbd34d028d2434ae0796ee42",
-    "m_Id": 0,
-    "m_DisplayName": "Tile",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
     "m_LiteralMode": false
 }
 
@@ -42969,7 +43003,7 @@
     "m_Hidden": false,
     "m_PerRendererData": false,
     "m_customAttributes": [],
-    "m_Value": 0.20000000298023225,
+    "m_Value": 1.0,
     "m_FloatType": 0,
     "m_LiteralFloatMode": false,
     "m_RangeValues": {
@@ -48828,6 +48862,22 @@
         "z": 0.0,
         "w": 0.0
     },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "f79940f5825244d3af739a78c2a14b13",
+    "m_Id": 0,
+    "m_DisplayName": "WindowTile",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
     "m_LiteralMode": false
 }
 

--- a/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_HDRP.shadergraph
+++ b/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_HDRP.shadergraph
@@ -1010,19 +1010,7 @@
             "m_Id": "2a5704d1c9d54289b57beb21da06787b"
         },
         {
-            "m_Id": "0b0cc6256e5e4d3588dde690c74af8e9"
-        },
-        {
-            "m_Id": "6d160b7b6cf440329f9c96c60bd320a0"
-        },
-        {
-            "m_Id": "365ed0300ee5452eb8a452da8d91f932"
-        },
-        {
             "m_Id": "b56ffae59aef491d99d39fa605c53a15"
-        },
-        {
-            "m_Id": "e249aa5adde74ff7877cbcca0a3abdcf"
         },
         {
             "m_Id": "dc07c0e63a1e4a3ea12f9526e1cc7eb1"
@@ -1190,9 +1178,6 @@
             "m_Id": "21ac0e8426b64715b98e8bdf31b8df94"
         },
         {
-            "m_Id": "e834d47a19be44009843db4a60450ef2"
-        },
-        {
             "m_Id": "51b6ac03086e4d17ae5050551943bbd3"
         },
         {
@@ -1341,6 +1326,12 @@
         },
         {
             "m_Id": "77ad06650cb24ee2afe26a48ff7b20ce"
+        },
+        {
+            "m_Id": "5016065c44b54d7eb7e38831f43e6192"
+        },
+        {
+            "m_Id": "7d6b6f1d824243d589e4aa47ba42fa18"
         }
     ],
     "m_GroupDatas": [
@@ -2943,7 +2934,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "70a1982d184e46838b8f5a6fa147e437"
+                    "m_Id": "5016065c44b54d7eb7e38831f43e6192"
                 },
                 "m_SlotId": 0
             }
@@ -2957,7 +2948,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "d4360e08258546d490de72e76d70f4f2"
+                    "m_Id": "70a1982d184e46838b8f5a6fa147e437"
                 },
                 "m_SlotId": 0
             }
@@ -3321,7 +3312,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "77ad06650cb24ee2afe26a48ff7b20ce"
+                    "m_Id": "7d6b6f1d824243d589e4aa47ba42fa18"
                 },
                 "m_SlotId": 0
             }
@@ -4108,6 +4099,34 @@
                     "m_Id": "41c5aa792c384b82b9dc9bfd8b5ce36c"
                 },
                 "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "7d6b6f1d824243d589e4aa47ba42fa18"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "77ad06650cb24ee2afe26a48ff7b20ce"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "7d6b6f1d824243d589e4aa47ba42fa18"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "d4360e08258546d490de72e76d70f4f2"
+                },
+                "m_SlotId": 0
             }
         },
         {
@@ -7182,17 +7201,7 @@
             "x": 2906.0,
             "y": 340.0
         },
-        "m_Blocks": [
-            {
-                "m_Id": "0b0cc6256e5e4d3588dde690c74af8e9"
-            },
-            {
-                "m_Id": "6d160b7b6cf440329f9c96c60bd320a0"
-            },
-            {
-                "m_Id": "365ed0300ee5452eb8a452da8d91f932"
-            }
-        ]
+        "m_Blocks": []
     },
     "m_FragmentContext": {
         "m_Position": {
@@ -7220,12 +7229,6 @@
             },
             {
                 "m_Id": "b56ffae59aef491d99d39fa605c53a15"
-            },
-            {
-                "m_Id": "e249aa5adde74ff7877cbcca0a3abdcf"
-            },
-            {
-                "m_Id": "e834d47a19be44009843db4a60450ef2"
             }
         ]
     },
@@ -7494,6 +7497,31 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "0288946dd3554271a00c2d5194d0090e",
+    "m_Id": 1,
+    "m_DisplayName": "",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DistanceNode",
     "m_ObjectId": "02b5bb6c0192442e8b3719c4f65756df",
     "m_Group": {
@@ -7682,8 +7710,8 @@
     "m_ObjectId": "0409f5b32a004a808906d5f43a3c5d40",
     "m_Title": "Roof Edge",
     "m_Position": {
-        "x": -1599.0001220703125,
-        "y": 3222.00048828125
+        "x": -1599.0,
+        "y": 3222.0
     }
 }
 
@@ -8037,8 +8065,8 @@
     "m_ObjectId": "06fa50583ea443de953f87fcbfc938c3",
     "m_Title": "Normal Y",
     "m_Position": {
-        "x": -2109.000244140625,
-        "y": 519.999755859375
+        "x": -2109.0,
+        "y": 520.0
     }
 }
 
@@ -8656,40 +8684,6 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "0b0cc6256e5e4d3588dde690c74af8e9",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "VertexDescription.Position",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "6afdc21139a64d7a9c7913a4399da808"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "VertexDescription.Position"
 }
 
 {
@@ -12340,6 +12334,31 @@
         "z": 0.0,
         "w": 0.0
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "1e1b8a9970524630ad2919a7262e4967",
+    "m_Id": 0,
+    "m_DisplayName": "",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
 }
 
 {
@@ -16022,40 +16041,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "365ed0300ee5452eb8a452da8d91f932",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "VertexDescription.Tangent",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "62ff9c5715f94fa4962a4474f8c105c7"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "VertexDescription.Tangent"
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
     "m_ObjectId": "369d65e6ed1a4c528fcb4f19a343e6ff",
     "m_Id": 1866388063,
@@ -18015,6 +18000,31 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "43d4fd23b90b4156a5a64141ae027e06",
+    "m_Id": 1,
+    "m_DisplayName": "",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": true
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "43d7375724ff4b74a40e84a2e13e5c3d",
     "m_Id": 2,
     "m_DisplayName": "T",
@@ -19904,6 +19914,42 @@
     },
     "m_Property": {
         "m_Id": "b2528cc8b34e45d89217088695e8a8a3"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.RedirectNodeData",
+    "m_ObjectId": "5016065c44b54d7eb7e38831f43e6192",
+    "m_Group": {
+        "m_Id": "656155abed2648b6bf803e4d5394beca"
+    },
+    "m_Name": "Redirect Node",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 1058.0,
+            "y": 3491.999755859375,
+            "width": 56.0,
+            "height": 24.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "1e1b8a9970524630ad2919a7262e4967"
+        },
+        {
+            "m_Id": "43d4fd23b90b4156a5a64141ae027e06"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
     }
 }
 
@@ -22941,30 +22987,6 @@
 }
 
 {
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.TangentMaterialSlot",
-    "m_ObjectId": "62ff9c5715f94fa4962a4474f8c105c7",
-    "m_Id": 0,
-    "m_DisplayName": "Tangent",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Tangent",
-    "m_StageCapability": 1,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": [],
-    "m_Space": 0
-}
-
-{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector3ShaderProperty",
     "m_ObjectId": "631b2e44385843b1b5e2e29fb91a366f",
@@ -23388,8 +23410,8 @@
     "m_ObjectId": "656155abed2648b6bf803e4d5394beca",
     "m_Title": "Fake GI",
     "m_Position": {
-        "x": 25.999755859375,
-        "y": 3366.00048828125
+        "x": 25.999998092651368,
+        "y": 3365.999755859375
     }
 }
 
@@ -24060,15 +24082,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalLitSubTarget",
-    "m_ObjectId": "6902cce589024d00a05b3ee5a3d364c7",
-    "m_WorkflowMode": 1,
-    "m_NormalDropOffSpace": 0,
-    "m_ClearCoat": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "6963571c9a01485d917ee12bf7df799d",
     "m_Id": 0,
@@ -24307,30 +24320,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PositionMaterialSlot",
-    "m_ObjectId": "6afdc21139a64d7a9c7913a4399da808",
-    "m_Id": 0,
-    "m_DisplayName": "Position",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Position",
-    "m_StageCapability": 1,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": [],
-    "m_Space": 0
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "6b07b86e38e34940bb64d93866470ed9",
     "m_Id": 0,
@@ -24508,40 +24497,6 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "6d160b7b6cf440329f9c96c60bd320a0",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "VertexDescription.Normal",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "e6ac44addd7f4ba99830af48908783d4"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "VertexDescription.Normal"
 }
 
 {
@@ -25087,8 +25042,8 @@
     "m_ObjectId": "6f3455e5e11545ba83ddff692b6d5f55",
     "m_Title": "Lod1Triplanar",
     "m_Position": {
-        "x": -1472.0001220703125,
-        "y": -3426.000244140625
+        "x": -1472.0,
+        "y": -3426.0
     }
 }
 
@@ -26306,6 +26261,31 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "7769b08eb2904035ab49c384173a751b",
+    "m_Id": 0,
+    "m_DisplayName": "",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
     "m_ObjectId": "77837c293aea474eb58fb056df82d48f",
@@ -26400,8 +26380,8 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 581.0000610351563,
-            "y": 494.0,
+            "x": 545.0000610351563,
+            "y": 267.0,
             "width": 56.0,
             "height": 24.0
         }
@@ -26455,7 +26435,7 @@
     "m_ObjectId": "7842b84efd7f4355a0c2d1947a3f5836",
     "m_Title": "MaskByHeight",
     "m_Position": {
-        "x": -2221.000244140625,
+        "x": -2221.0,
         "y": 831.0
     }
 }
@@ -27099,6 +27079,42 @@
         "z": 0.0
     },
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.RedirectNodeData",
+    "m_ObjectId": "7d6b6f1d824243d589e4aa47ba42fa18",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Redirect Node",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 421.0,
+            "y": -1039.0,
+            "width": 56.000152587890628,
+            "height": 24.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "7769b08eb2904035ab49c384173a751b"
+        },
+        {
+            "m_Id": "0288946dd3554271a00c2d5194d0090e"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -29302,7 +29318,7 @@
     "m_ObjectId": "8b039dcfcbba48eeb2b8506402fce9f0",
     "m_Title": "Wall",
     "m_Position": {
-        "x": -3282.000244140625,
+        "x": -3282.0,
         "y": -345.0
     }
 }
@@ -29827,7 +29843,7 @@
     "m_ObjectId": "8cffa81326e84675ba7188a9e649c422",
     "m_Title": "Scaling by Distance",
     "m_Position": {
-        "x": -503.0001220703125,
+        "x": -503.0,
         "y": -809.0
     }
 }
@@ -30447,22 +30463,6 @@
         "e32": 0.0,
         "e33": 1.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "8f2ce5153e9a45ff996c566775e1f15b",
-    "m_Id": 0,
-    "m_DisplayName": "Metallic",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Metallic",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
 }
 
 {
@@ -43615,7 +43615,7 @@
         "z": 0.0,
         "w": 0.0
     },
-    "m_LiteralMode": true
+    "m_LiteralMode": false
 }
 
 {
@@ -44987,56 +44987,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "e249aa5adde74ff7877cbcca0a3abdcf",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Metallic",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "8f2ce5153e9a45ff996c566775e1f15b"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Metallic"
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "e280e8ba3f4146aca7c353782ea8c79e",
-    "m_Id": 0,
-    "m_DisplayName": "Alpha Clip Threshold",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "AlphaClipThreshold",
-    "m_StageCapability": 2,
-    "m_Value": 0.5,
-    "m_DefaultValue": 0.5,
-    "m_Labels": [],
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.CameraNode",
     "m_ObjectId": "e2ad8a0f29f945babc46c8fe5224905f",
     "m_Group": {
@@ -45919,8 +45869,8 @@
     "m_ObjectId": "e6713c9dd4e3412a9a8e8afe50f5efb9",
     "m_Title": "Roof Top",
     "m_Position": {
-        "x": -1544.0001220703125,
-        "y": 2164.000244140625
+        "x": -1544.0,
+        "y": 2164.0
     }
 }
 
@@ -45947,30 +45897,6 @@
         "w": 0.0
     },
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
-    "m_ObjectId": "e6ac44addd7f4ba99830af48908783d4",
-    "m_Id": 0,
-    "m_DisplayName": "Normal",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Normal",
-    "m_StageCapability": 1,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": [],
-    "m_Space": 0
 }
 
 {
@@ -46379,40 +46305,6 @@
         "w": 0.0
     },
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "e834d47a19be44009843db4a60450ef2",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.AlphaClipThreshold",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "e280e8ba3f4146aca7c353782ea8c79e"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.AlphaClipThreshold"
 }
 
 {
@@ -49596,7 +49488,7 @@
     "m_Title": "Emmision Map HDRP",
     "m_Position": {
         "x": 740.0,
-        "y": 1118.000244140625
+        "y": 1117.999755859375
     }
 }
 

--- a/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_HDRP.shadergraph
+++ b/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_HDRP.shadergraph
@@ -4,37 +4,37 @@
     "m_ObjectId": "0717bbe20a94494da7d0b82d065893c9",
     "m_Properties": [
         {
-            "m_Id": "04052d05f38847259e99e9759f7a5455"
+            "m_Id": "a2a8a714e6d843c4ae8d0888b912da24"
         },
         {
-            "m_Id": "1e81c5d7f04a4ba9bfccbbb370fec9a7"
+            "m_Id": "75fb5b24a9724ea1b675131c23522d13"
         },
         {
-            "m_Id": "11d17b32be9247d8afb1e081f815bcf8"
+            "m_Id": "631b2e44385843b1b5e2e29fb91a366f"
         },
         {
-            "m_Id": "715b69dbc32a4aefa1890521ce28bc66"
+            "m_Id": "26f5377eeaca4c1198f8eaed1ebdf4cb"
         },
         {
-            "m_Id": "e665594047ea42ec9cce2355de477c43"
+            "m_Id": "ac503bef496344ad8b9dfb5bbb213f9b"
         },
         {
-            "m_Id": "d40b57b8ad414fcfa8dc645697ce0930"
+            "m_Id": "70d3c3d92c2a46f0a90c8ce6d51ade25"
         },
         {
-            "m_Id": "00fead8eabd94d8fa536359fbdf70701"
+            "m_Id": "059fefe3c6cc4f79a88d71e70088f647"
         },
         {
-            "m_Id": "e26a80b03d614a13999c3fa38b99a9b2"
+            "m_Id": "647a74e6acc74647aff2344abb5e068f"
         },
         {
-            "m_Id": "9934abfc36164c329a0480b30ef0c8eb"
+            "m_Id": "36e132d8adbe43bfb2803632ab726ded"
         },
         {
-            "m_Id": "a131527a1e2f4ee08b1be704ee20ee5b"
+            "m_Id": "dc022c39e6bb4ac8afc5ea58baa21213"
         },
         {
-            "m_Id": "2f0fc2f20ea54732a65ea368672ea06c"
+            "m_Id": "bac640b190f64590a1e634b743694ff4"
         },
         {
             "m_Id": "f334ce1baf504f66a69fe2f0724db932"
@@ -195,7 +195,7 @@
             "m_Id": "bfa0cf41fd70436491fcd94fb1313a03"
         },
         {
-            "m_Id": "2d9ffd75203e4c8fa500dee8a21e5619"
+            "m_Id": "351bb73335a44d568cf12d62be84c501"
         },
         {
             "m_Id": "c8d4896e391f4dc2bcc35215c1325aef"
@@ -1010,7 +1010,19 @@
             "m_Id": "2a5704d1c9d54289b57beb21da06787b"
         },
         {
+            "m_Id": "0b0cc6256e5e4d3588dde690c74af8e9"
+        },
+        {
+            "m_Id": "6d160b7b6cf440329f9c96c60bd320a0"
+        },
+        {
+            "m_Id": "365ed0300ee5452eb8a452da8d91f932"
+        },
+        {
             "m_Id": "b56ffae59aef491d99d39fa605c53a15"
+        },
+        {
+            "m_Id": "e249aa5adde74ff7877cbcca0a3abdcf"
         },
         {
             "m_Id": "dc07c0e63a1e4a3ea12f9526e1cc7eb1"
@@ -1178,6 +1190,9 @@
             "m_Id": "21ac0e8426b64715b98e8bdf31b8df94"
         },
         {
+            "m_Id": "e834d47a19be44009843db4a60450ef2"
+        },
+        {
             "m_Id": "51b6ac03086e4d17ae5050551943bbd3"
         },
         {
@@ -1220,109 +1235,112 @@
             "m_Id": "dc7a5ef83d64461082100008a68c9818"
         },
         {
-            "m_Id": "04c6e09d9be042eea59b13e6375e8eac"
+            "m_Id": "18f1c67e7ffd4b209bcd96a342f5425c"
         },
         {
-            "m_Id": "0a3c7139a6ad4689ab369357f56bf2ce"
+            "m_Id": "8a4d0731ab8d453482c4bd4284acbdd0"
         },
         {
-            "m_Id": "e82d6489234b439abbbbe6c17117867e"
+            "m_Id": "707cf90768c64c20b77beae773e25ff9"
         },
         {
-            "m_Id": "18240f0837f64dee95ee4b225b4f27e0"
+            "m_Id": "46d368d78872458097681745a2a7266c"
         },
         {
-            "m_Id": "ca31e9638dae41d0b3e84ef4321cf93d"
+            "m_Id": "d9011f8c25df48f3b900828b632aff09"
         },
         {
-            "m_Id": "d9f4c6bb247b42f381c614a556e8620f"
+            "m_Id": "be4a444895604fa496a169de554c166e"
         },
         {
-            "m_Id": "5bca8e26c69a4224a6f329cbe9e4ae68"
+            "m_Id": "efdaab6eb41d48d6a696c8e373a86091"
         },
         {
-            "m_Id": "89deb85c0ab54a3198ac53487d18cf90"
+            "m_Id": "5aa997c574014e11b576ad4ec1c94c35"
         },
         {
-            "m_Id": "50ae29548026417a8da5995e89c7320b"
+            "m_Id": "850411bd31e94ff4a0ee556aeccfec4b"
         },
         {
-            "m_Id": "0c61c03614594dff98ea43a3e62dce93"
+            "m_Id": "e560845eae7b46d7a62e7a8872791fff"
         },
         {
-            "m_Id": "810938c97ec14208b380f758afdbd06c"
+            "m_Id": "f802801104f648089502d979976116e8"
         },
         {
-            "m_Id": "2e118fc47d494e5ca5bb7b16d05c7987"
+            "m_Id": "f89163b270724e249756da6d52195d6e"
         },
         {
-            "m_Id": "13af348179844dddbff3630952fcd7a7"
+            "m_Id": "d216079f5fc043aca2c3d4f14c9d623e"
         },
         {
-            "m_Id": "9f5d83a0eee04ccd89093c86ce970031"
+            "m_Id": "0d94147a14574512bd5a9eb0868dfd59"
         },
         {
-            "m_Id": "564aefb1013746cc93a256ce3478f4af"
+            "m_Id": "29ce046422b4421784589d3161022b52"
         },
         {
-            "m_Id": "e865495b677949199fc7cfe0b2a1e110"
+            "m_Id": "e4e0c95635014540b57547629ebdc4d5"
         },
         {
-            "m_Id": "1b1558d4a4724fcfbaecbe742bd0945c"
+            "m_Id": "416876399b8f4fadbe6412102b5ea3dc"
         },
         {
-            "m_Id": "5b1da221343f450d93f75ba8776cb5a8"
+            "m_Id": "a4ed2a3823c54e3aa189ab63f21c9e92"
         },
         {
-            "m_Id": "1522ba646a3644e3ab0093856fa2d6a0"
+            "m_Id": "eea85506be6b4e5586acf6f5727fe907"
         },
         {
-            "m_Id": "735f22a9ce9d479999868eefdd3b4a7b"
+            "m_Id": "af33720f092d4a1680a6c8587627b511"
         },
         {
-            "m_Id": "e1341d1c1d554cc482019cd251bba3af"
+            "m_Id": "d887090746fe4c06a32db60fcd0c2736"
         },
         {
-            "m_Id": "968514b2b5b54f8ba250cab2e309fa94"
+            "m_Id": "91ebbc86e49747e59e198ad1f551edf0"
         },
         {
-            "m_Id": "57e24ad789254e5a9b28353369b81644"
+            "m_Id": "13036d9d6c104b7e933bdd072b141345"
         },
         {
-            "m_Id": "477d794df48540e6915048d32fb65c4b"
+            "m_Id": "36b29c9b6e324b8da8e2f4c33067a691"
         },
         {
-            "m_Id": "5d9b6944697a4c66887818ca156362c3"
+            "m_Id": "f6385e75584846a5bd6880b61c6d3a8e"
         },
         {
-            "m_Id": "56dcecd7f8d247f5bb47c9f15280ba58"
+            "m_Id": "dab594fecaa24bbaae91506572f095f1"
         },
         {
-            "m_Id": "aa77d1b9745d4a46874483cc2d487827"
+            "m_Id": "ba7c82cf79634a40802f68307af1163b"
         },
         {
-            "m_Id": "d467bebbe0404637ac83059b48b88639"
+            "m_Id": "5c2aec49aec34c24a3d3c407bf81c603"
         },
         {
-            "m_Id": "41d04f2bd87646178231e4706a7b853e"
+            "m_Id": "376db249a4c2409499bd05bbf72e4eb3"
         },
         {
-            "m_Id": "b4a2ff8b650d4363bbe9cdb3e0850f5b"
+            "m_Id": "3078f26400094bf4a6f8875fa3c71deb"
         },
         {
-            "m_Id": "64eafe7bdf424c40bb32f9759c2a1acd"
+            "m_Id": "e8b63c463b4b4a4e8a020233538a3216"
         },
         {
-            "m_Id": "7c1ec6bd2e4246eda00556ce896b9a01"
+            "m_Id": "191796285eed47bb9e68132f2bd50588"
         },
         {
-            "m_Id": "70790f4f755c4f3db65cb140ab10c896"
+            "m_Id": "c0f4eea11130445ba24bf938aa8fa51e"
         },
         {
-            "m_Id": "4a52a9ac6ea541f8ae6c249da5746304"
+            "m_Id": "90e36ed1fc0b4762b9205ec008f15467"
         },
         {
-            "m_Id": "fe5bb7f79f454ff89e4ec0f4d165ac13"
+            "m_Id": "a679864b96aa47b4b1c09860312e9b85"
+        },
+        {
+            "m_Id": "77ad06650cb24ee2afe26a48ff7b20ce"
         }
     ],
     "m_GroupDatas": [
@@ -1357,7 +1375,7 @@
             "m_Id": "656155abed2648b6bf803e4d5394beca"
         },
         {
-            "m_Id": "268aebd00d0b4e74921a871f08492592"
+            "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
         }
     ],
     "m_StickyNoteDatas": [],
@@ -1463,20 +1481,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "04c6e09d9be042eea59b13e6375e8eac"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "50ae29548026417a8da5995e89c7320b"
-                },
-                "m_SlotId": -571921639
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "06900c61fe584efc81d77364ad2b70fd"
                 },
                 "m_SlotId": 3
@@ -1556,20 +1560,6 @@
                     "m_Id": "70064ee3b7494b27b20bd0ef1356b34d"
                 },
                 "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "0a3c7139a6ad4689ab369357f56bf2ce"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "18240f0837f64dee95ee4b225b4f27e0"
-                },
-                "m_SlotId": 1426526534
             }
         },
         {
@@ -1659,20 +1649,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "0c61c03614594dff98ea43a3e62dce93"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "50ae29548026417a8da5995e89c7320b"
-                },
-                "m_SlotId": -985074803
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "0ccd316e4d3d479fa8399cab603477d9"
                 },
                 "m_SlotId": 2
@@ -1696,6 +1672,20 @@
                     "m_Id": "a2c58617fbcd4b659500c34fb29d92bf"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "0d94147a14574512bd5a9eb0868dfd59"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "416876399b8f4fadbe6412102b5ea3dc"
+                },
+                "m_SlotId": 1
             }
         },
         {
@@ -1799,6 +1789,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "13036d9d6c104b7e933bdd072b141345"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "f802801104f648089502d979976116e8"
+                },
+                "m_SlotId": -571921639
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "134a67bacc394813aa91f0510e0e6553"
                 },
                 "m_SlotId": 0
@@ -1813,20 +1817,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "13af348179844dddbff3630952fcd7a7"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "810938c97ec14208b380f758afdbd06c"
-                },
-                "m_SlotId": -985074803
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "13c74b7b00084aaf9a502aa7851d2fbb"
                 },
                 "m_SlotId": 0
@@ -1836,20 +1826,6 @@
                     "m_Id": "6d2fb9bc8e204ceebec00ccb4f12eb50"
                 },
                 "m_SlotId": -813125564
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "1522ba646a3644e3ab0093856fa2d6a0"
-                },
-                "m_SlotId": 2
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "89deb85c0ab54a3198ac53487d18cf90"
-                },
-                "m_SlotId": 1
             }
         },
         {
@@ -1897,20 +1873,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "18240f0837f64dee95ee4b225b4f27e0"
-                },
-                "m_SlotId": 1
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "89deb85c0ab54a3198ac53487d18cf90"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "18b09c21a0f24c24b1b738139ae76342"
                 },
                 "m_SlotId": 0
@@ -1934,6 +1896,34 @@
                     "m_Id": "dd96753e81664504879224527b5f10a3"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "18f1c67e7ffd4b209bcd96a342f5425c"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "850411bd31e94ff4a0ee556aeccfec4b"
+                },
+                "m_SlotId": -571921639
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "191796285eed47bb9e68132f2bd50588"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "0d94147a14574512bd5a9eb0868dfd59"
+                },
+                "m_SlotId": 127769700
             }
         },
         {
@@ -1974,20 +1964,6 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "90a44e5acc5b4340a115a48e3a5a8998"
-                },
-                "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "1b1558d4a4724fcfbaecbe742bd0945c"
-                },
-                "m_SlotId": 2
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "1522ba646a3644e3ab0093856fa2d6a0"
                 },
                 "m_SlotId": 1
             }
@@ -2331,6 +2307,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "29ce046422b4421784589d3161022b52"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "0d94147a14574512bd5a9eb0868dfd59"
+                },
+                "m_SlotId": -985074803
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "2a2292cc0e6944af91fc73832370fec0"
                 },
                 "m_SlotId": 2
@@ -2471,20 +2461,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "2e118fc47d494e5ca5bb7b16d05c7987"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "810938c97ec14208b380f758afdbd06c"
-                },
-                "m_SlotId": 878772836
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "2ea7c51d486340d2a8f1368aa6daa55e"
                 },
                 "m_SlotId": 1
@@ -2536,6 +2512,20 @@
                     "m_Id": "9344cde66e46489aa38a5b7309522c83"
                 },
                 "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "3078f26400094bf4a6f8875fa3c71deb"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "d9011f8c25df48f3b900828b632aff09"
+                },
+                "m_SlotId": 127769700
             }
         },
         {
@@ -2597,6 +2587,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "36b29c9b6e324b8da8e2f4c33067a691"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "d9011f8c25df48f3b900828b632aff09"
+                },
+                "m_SlotId": 1426526534
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "36e2e7f44f614f6cbea4dba824ccfea4"
                 },
                 "m_SlotId": 0
@@ -2606,6 +2610,20 @@
                     "m_Id": "0a30e104a7a642a4bc6e586805321f01"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "376db249a4c2409499bd05bbf72e4eb3"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "850411bd31e94ff4a0ee556aeccfec4b"
+                },
+                "m_SlotId": 127769700
             }
         },
         {
@@ -2793,6 +2811,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "416876399b8f4fadbe6412102b5ea3dc"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "eea85506be6b4e5586acf6f5727fe907"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "41c5aa792c384b82b9dc9bfd8b5ce36c"
                 },
                 "m_SlotId": 0
@@ -2802,20 +2834,6 @@
                     "m_Id": "70a1982d184e46838b8f5a6fa147e437"
                 },
                 "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "41d04f2bd87646178231e4706a7b853e"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "50ae29548026417a8da5995e89c7320b"
-                },
-                "m_SlotId": 127769700
             }
         },
         {
@@ -2877,15 +2895,15 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "477d794df48540e6915048d32fb65c4b"
+                    "m_Id": "46d368d78872458097681745a2a7266c"
                 },
-                "m_SlotId": 0
+                "m_SlotId": 1
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "ca31e9638dae41d0b3e84ef4321cf93d"
+                    "m_Id": "5aa997c574014e11b576ad4ec1c94c35"
                 },
-                "m_SlotId": 1426526534
+                "m_SlotId": 0
             }
         },
         {
@@ -2942,20 +2960,6 @@
                     "m_Id": "d4360e08258546d490de72e76d70f4f2"
                 },
                 "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "4a52a9ac6ea541f8ae6c249da5746304"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "18240f0837f64dee95ee4b225b4f27e0"
-                },
-                "m_SlotId": 878772836
             }
         },
         {
@@ -3054,20 +3058,6 @@
                     "m_Id": "817710b10a84454cbcdeadb1af74b7ef"
                 },
                 "m_SlotId": 6
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "50ae29548026417a8da5995e89c7320b"
-                },
-                "m_SlotId": 1
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "5b1da221343f450d93f75ba8776cb5a8"
-                },
-                "m_SlotId": 0
             }
         },
         {
@@ -3199,34 +3189,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "564aefb1013746cc93a256ce3478f4af"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "9f5d83a0eee04ccd89093c86ce970031"
-                },
-                "m_SlotId": -985074803
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "56dcecd7f8d247f5bb47c9f15280ba58"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "50ae29548026417a8da5995e89c7320b"
-                },
-                "m_SlotId": 1426526534
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "56dd99358eba4d6bbe64edb79e78dff2"
                 },
                 "m_SlotId": 0
@@ -3278,20 +3240,6 @@
                     "m_Id": "637f6d0647714ff78197e080b5b7e494"
                 },
                 "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "57e24ad789254e5a9b28353369b81644"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "810938c97ec14208b380f758afdbd06c"
-                },
-                "m_SlotId": -571921639
             }
         },
         {
@@ -3367,13 +3315,13 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "5b1da221343f450d93f75ba8776cb5a8"
+                    "m_Id": "5aa997c574014e11b576ad4ec1c94c35"
                 },
                 "m_SlotId": 2
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "1522ba646a3644e3ab0093856fa2d6a0"
+                    "m_Id": "77ad06650cb24ee2afe26a48ff7b20ce"
                 },
                 "m_SlotId": 0
             }
@@ -3395,15 +3343,15 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "5bca8e26c69a4224a6f329cbe9e4ae68"
+                    "m_Id": "5c2aec49aec34c24a3d3c407bf81c603"
                 },
                 "m_SlotId": 0
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "50ae29548026417a8da5995e89c7320b"
+                    "m_Id": "46d368d78872458097681745a2a7266c"
                 },
-                "m_SlotId": 878772836
+                "m_SlotId": 127769700
             }
         },
         {
@@ -3446,20 +3394,6 @@
                     "m_Id": "026a2d6eb7fd48269cb06aefb2a8439c"
                 },
                 "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "5d9b6944697a4c66887818ca156362c3"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "ca31e9638dae41d0b3e84ef4321cf93d"
-                },
-                "m_SlotId": -571921639
             }
         },
         {
@@ -3684,20 +3618,6 @@
                     "m_Id": "b4ca356cedfc4bce9795078eba7f7bdf"
                 },
                 "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "64eafe7bdf424c40bb32f9759c2a1acd"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "810938c97ec14208b380f758afdbd06c"
-                },
-                "m_SlotId": 127769700
             }
         },
         {
@@ -3969,6 +3889,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "707cf90768c64c20b77beae773e25ff9"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "46d368d78872458097681745a2a7266c"
+                },
+                "m_SlotId": -985074803
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "70a1982d184e46838b8f5a6fa147e437"
                 },
                 "m_SlotId": 2
@@ -4006,20 +3940,6 @@
                     "m_Id": "0ac817831eda436898bbe512abb2c805"
                 },
                 "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "735f22a9ce9d479999868eefdd3b4a7b"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "9f5d83a0eee04ccd89093c86ce970031"
-                },
-                "m_SlotId": 1426526534
             }
         },
         {
@@ -4095,6 +4015,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "77ad06650cb24ee2afe26a48ff7b20ce"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "e2435d38dde8456199b72e39c30dbe93"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "791372b6647b406eb9f5a718f7c1c06b"
                 },
                 "m_SlotId": 0
@@ -4151,20 +4085,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "7c1ec6bd2e4246eda00556ce896b9a01"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "9f5d83a0eee04ccd89093c86ce970031"
-                },
-                "m_SlotId": 127769700
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "7ca2d886c1684a20891cf9e149f8d730"
                 },
                 "m_SlotId": 2
@@ -4202,20 +4122,6 @@
                     "m_Id": "21ac0e8426b64715b98e8bdf31b8df94"
                 },
                 "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "810938c97ec14208b380f758afdbd06c"
-                },
-                "m_SlotId": 1
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "1b1558d4a4724fcfbaecbe742bd0945c"
-                },
-                "m_SlotId": 0
             }
         },
         {
@@ -4319,6 +4225,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "850411bd31e94ff4a0ee556aeccfec4b"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "a4ed2a3823c54e3aa189ab63f21c9e92"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "857d8943aa0c4ad786e26f35c739a30e"
                 },
                 "m_SlotId": 2
@@ -4389,15 +4309,15 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "89deb85c0ab54a3198ac53487d18cf90"
+                    "m_Id": "8a4d0731ab8d453482c4bd4284acbdd0"
                 },
-                "m_SlotId": 2
+                "m_SlotId": 0
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "e2435d38dde8456199b72e39c30dbe93"
+                    "m_Id": "46d368d78872458097681745a2a7266c"
                 },
-                "m_SlotId": 0
+                "m_SlotId": 1426526534
             }
         },
         {
@@ -4599,6 +4519,34 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "90e36ed1fc0b4762b9205ec008f15467"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "46d368d78872458097681745a2a7266c"
+                },
+                "m_SlotId": 878772836
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "91ebbc86e49747e59e198ad1f551edf0"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "f802801104f648089502d979976116e8"
+                },
+                "m_SlotId": 1426526534
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "929392ab14a54e42962540662f437ee1"
                 },
                 "m_SlotId": 0
@@ -4753,20 +4701,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "968514b2b5b54f8ba250cab2e309fa94"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "810938c97ec14208b380f758afdbd06c"
-                },
-                "m_SlotId": 1426526534
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "97781e7a121c40769bfac244c6f32fee"
                 },
                 "m_SlotId": 1
@@ -4893,20 +4827,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "9f5d83a0eee04ccd89093c86ce970031"
-                },
-                "m_SlotId": 1
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "1b1558d4a4724fcfbaecbe742bd0945c"
-                },
-                "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "a0ff854cef7d4371a2b23bfcf620b5cc"
                 },
                 "m_SlotId": 1
@@ -4991,6 +4911,34 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "a4ed2a3823c54e3aa189ab63f21c9e92"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "eea85506be6b4e5586acf6f5727fe907"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "a679864b96aa47b4b1c09860312e9b85"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "d9011f8c25df48f3b900828b632aff09"
+                },
+                "m_SlotId": 878772836
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "a8a982040a274a4381fb2aa641da8180"
                 },
                 "m_SlotId": 0
@@ -5000,20 +4948,6 @@
                     "m_Id": "e4fa736fe8cd469e87ba4b4ffee717fe"
                 },
                 "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "aa77d1b9745d4a46874483cc2d487827"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "18240f0837f64dee95ee4b225b4f27e0"
-                },
-                "m_SlotId": -571921639
             }
         },
         {
@@ -5112,6 +5046,20 @@
                     "m_Id": "acf00be0ff3e498c897d2088a029cb68"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "af33720f092d4a1680a6c8587627b511"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "0d94147a14574512bd5a9eb0868dfd59"
+                },
+                "m_SlotId": 1426526534
             }
         },
         {
@@ -5238,20 +5186,6 @@
                     "m_Id": "0e5da2df43464114997baab3a942a0ac"
                 },
                 "m_SlotId": 1466395117
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "b4a2ff8b650d4363bbe9cdb3e0850f5b"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "ca31e9638dae41d0b3e84ef4321cf93d"
-                },
-                "m_SlotId": 127769700
             }
         },
         {
@@ -5495,6 +5429,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "ba7c82cf79634a40802f68307af1163b"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "46d368d78872458097681745a2a7266c"
+                },
+                "m_SlotId": -571921639
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "bb5af719f8b1427fa9af3dccd9240400"
                 },
                 "m_SlotId": 1
@@ -5574,6 +5522,20 @@
                     "m_Id": "026a2d6eb7fd48269cb06aefb2a8439c"
                 },
                 "m_SlotId": 2
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "be4a444895604fa496a169de554c166e"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "d9011f8c25df48f3b900828b632aff09"
+                },
+                "m_SlotId": -985074803
             }
         },
         {
@@ -5831,20 +5793,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "ca31e9638dae41d0b3e84ef4321cf93d"
-                },
-                "m_SlotId": 1
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "5b1da221343f450d93f75ba8776cb5a8"
-                },
-                "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "cbf90eb123e24701bda23bd05bb1f0c2"
                 },
                 "m_SlotId": 2
@@ -6013,6 +5961,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "d216079f5fc043aca2c3d4f14c9d623e"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "f802801104f648089502d979976116e8"
+                },
+                "m_SlotId": -985074803
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "d232b8b83b344e0f966db59bb9ecd090"
                 },
                 "m_SlotId": 0
@@ -6111,20 +6073,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "d467bebbe0404637ac83059b48b88639"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "18240f0837f64dee95ee4b225b4f27e0"
-                },
-                "m_SlotId": 127769700
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "d5a4d5a6a7264f7db62e8e6ef433a96b"
                 },
                 "m_SlotId": 1
@@ -6195,6 +6143,34 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "d887090746fe4c06a32db60fcd0c2736"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "0d94147a14574512bd5a9eb0868dfd59"
+                },
+                "m_SlotId": -571921639
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "d9011f8c25df48f3b900828b632aff09"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "a4ed2a3823c54e3aa189ab63f21c9e92"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "d9c62977f9164567a322f5ebda6349e1"
                 },
                 "m_SlotId": 2
@@ -6204,20 +6180,6 @@
                     "m_Id": "88c93a7171514fdd87bcf9da570e5d1a"
                 },
                 "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "d9f4c6bb247b42f381c614a556e8620f"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "ca31e9638dae41d0b3e84ef4321cf93d"
-                },
-                "m_SlotId": -985074803
             }
         },
         {
@@ -6246,6 +6208,20 @@
                     "m_Id": "3054352643654b049fed0fc2717ea8c1"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "dab594fecaa24bbaae91506572f095f1"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "850411bd31e94ff4a0ee556aeccfec4b"
+                },
+                "m_SlotId": 1426526534
             }
         },
         {
@@ -6433,20 +6409,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "e1341d1c1d554cc482019cd251bba3af"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "9f5d83a0eee04ccd89093c86ce970031"
-                },
-                "m_SlotId": -571921639
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "e240bc2ed29c4d7d93d3cae8dd12700f"
                 },
                 "m_SlotId": 1
@@ -6503,6 +6465,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "e4e0c95635014540b57547629ebdc4d5"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "0d94147a14574512bd5a9eb0868dfd59"
+                },
+                "m_SlotId": 878772836
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "e4fa736fe8cd469e87ba4b4ffee717fe"
                 },
                 "m_SlotId": 2
@@ -6526,6 +6502,20 @@
                     "m_Id": "40566934bc6d424bb428c296fa6463c9"
                 },
                 "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "e560845eae7b46d7a62e7a8872791fff"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "850411bd31e94ff4a0ee556aeccfec4b"
+                },
+                "m_SlotId": -985074803
             }
         },
         {
@@ -6573,29 +6563,15 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "e82d6489234b439abbbbe6c17117867e"
+                    "m_Id": "e8b63c463b4b4a4e8a020233538a3216"
                 },
                 "m_SlotId": 0
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "18240f0837f64dee95ee4b225b4f27e0"
+                    "m_Id": "f802801104f648089502d979976116e8"
                 },
-                "m_SlotId": -985074803
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "e865495b677949199fc7cfe0b2a1e110"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "9f5d83a0eee04ccd89093c86ce970031"
-                },
-                "m_SlotId": 878772836
+                "m_SlotId": 127769700
             }
         },
         {
@@ -6797,6 +6773,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "eea85506be6b4e5586acf6f5727fe907"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "5aa997c574014e11b576ad4ec1c94c35"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "eed1964910434d9497111e5adbb88980"
                 },
                 "m_SlotId": 2
@@ -6834,6 +6824,20 @@
                     "m_Id": "4063ee3941de43008e917d9657b54611"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "efdaab6eb41d48d6a696c8e373a86091"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "850411bd31e94ff4a0ee556aeccfec4b"
+                },
+                "m_SlotId": 878772836
             }
         },
         {
@@ -6979,6 +6983,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "f6385e75584846a5bd6880b61c6d3a8e"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "d9011f8c25df48f3b900828b632aff09"
+                },
+                "m_SlotId": -571921639
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "f6ac2b23f78148ae9edd3ec3390b2269"
                 },
                 "m_SlotId": 3
@@ -6988,6 +7006,34 @@
                     "m_Id": "6d2fb9bc8e204ceebec00ccb4f12eb50"
                 },
                 "m_SlotId": 631652120
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "f802801104f648089502d979976116e8"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "416876399b8f4fadbe6412102b5ea3dc"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "f89163b270724e249756da6d52195d6e"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "f802801104f648089502d979976116e8"
+                },
+                "m_SlotId": 878772836
             }
         },
         {
@@ -7119,20 +7165,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "fe5bb7f79f454ff89e4ec0f4d165ac13"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "ca31e9638dae41d0b3e84ef4321cf93d"
-                },
-                "m_SlotId": 878772836
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "ff322e1e1d454d318c91c34621d8b205"
                 },
                 "m_SlotId": 0
@@ -7150,7 +7182,17 @@
             "x": 2906.0,
             "y": 340.0
         },
-        "m_Blocks": []
+        "m_Blocks": [
+            {
+                "m_Id": "0b0cc6256e5e4d3588dde690c74af8e9"
+            },
+            {
+                "m_Id": "6d160b7b6cf440329f9c96c60bd320a0"
+            },
+            {
+                "m_Id": "365ed0300ee5452eb8a452da8d91f932"
+            }
+        ]
     },
     "m_FragmentContext": {
         "m_Position": {
@@ -7178,6 +7220,12 @@
             },
             {
                 "m_Id": "b56ffae59aef491d99d39fa605c53a15"
+            },
+            {
+                "m_Id": "e249aa5adde74ff7877cbcca0a3abdcf"
+            },
+            {
+                "m_Id": "e834d47a19be44009843db4a60450ef2"
             }
         ]
     },
@@ -7319,62 +7367,6 @@
 }
 
 {
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector3ShaderProperty",
-    "m_ObjectId": "00fead8eabd94d8fa536359fbdf70701",
-    "m_Guid": {
-        "m_GuidSerialized": "fc77bee6-b123-412c-b8f3-936de9958b9e"
-    },
-    "promotedFromAssetID": "",
-    "promotedFromCategoryName": "",
-    "promotedOrdering": -1,
-    "m_Name": "ZCoef",
-    "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "ZCoef",
-    "m_DefaultReferenceName": "_ZCoef",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
-    "m_DismissedVersion": 0,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_PerRendererData": false,
-    "m_customAttributes": [],
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "016d1fe6cc3c4a959fa33c01288ea3c0",
-    "m_Id": 716731476,
-    "m_DisplayName": "normal",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_normal",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 1.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "0179106697744f439bcb78bb61039dd3",
@@ -7498,29 +7490,6 @@
         "e32": 0.0,
         "e33": 1.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "027d47fb39154492bf0888a12c4816d0",
-    "m_Id": -571921639,
-    "m_DisplayName": "origin",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_origin",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -7709,42 +7678,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
-    "m_ObjectId": "04052d05f38847259e99e9759f7a5455",
-    "m_Guid": {
-        "m_GuidSerialized": "237cb45d-aa9d-41c3-8dd1-527665b0e8fe"
-    },
-    "promotedFromAssetID": "",
-    "promotedFromCategoryName": "",
-    "promotedOrdering": -1,
-    "m_Name": "RightTexture",
-    "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "RightTexture",
-    "m_DefaultReferenceName": "_RightTexture",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
-    "m_DismissedVersion": 0,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_PerRendererData": false,
-    "m_customAttributes": [],
-    "m_Value": {
-        "m_SerializedTexture": "",
-        "m_Guid": ""
-    },
-    "isMainTexture": false,
-    "useTilingAndOffset": false,
-    "useTexelSize": true,
-    "m_Modifiable": true,
-    "m_DefaultType": 0
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.GroupData",
     "m_ObjectId": "0409f5b32a004a808906d5f43a3c5d40",
     "m_Title": "Roof Edge",
@@ -7801,42 +7734,6 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "04c6e09d9be042eea59b13e6375e8eac",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -949.0001831054688,
-            "y": -2723.000244140625,
-            "width": 96.0,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "b62334f7eef04807a2a19824244e037d"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "2f0fc2f20ea54732a65ea368672ea06c"
-    }
 }
 
 {
@@ -7901,6 +7798,42 @@
         "e32": 0.0,
         "e33": 1.0
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
+    "m_ObjectId": "059fefe3c6cc4f79a88d71e70088f647",
+    "m_Guid": {
+        "m_GuidSerialized": "054c9d92-eff4-40a1-80eb-039a287e890b"
+    },
+    "promotedFromAssetID": "",
+    "promotedFromCategoryName": "",
+    "promotedOrdering": -1,
+    "m_Name": "BackTexture",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "BackTexture",
+    "m_DefaultReferenceName": "_BackTexture",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_PerRendererData": false,
+    "m_customAttributes": [],
+    "m_Value": {
+        "m_SerializedTexture": "",
+        "m_Guid": ""
+    },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
+    "useTexelSize": true,
+    "m_Modifiable": true,
+    "m_DefaultType": 0
 }
 
 {
@@ -8025,7 +7958,8 @@
     "m_TessellationShapeFactor": 0.75,
     "m_TessellationBackFaceCullEpsilon": -0.25,
     "m_TessellationMaxDisplacement": 0.009999999776482582,
-    "m_Version": 1,
+    "m_DebugSymbols": false,
+    "m_Version": 2,
     "inspectorFoldoutMask": 9
 }
 
@@ -8099,37 +8033,12 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "0692e4a05d764cf49cc3757b0d837698",
-    "m_Id": 2,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.GroupData",
     "m_ObjectId": "06fa50583ea443de953f87fcbfc938c3",
     "m_Title": "Normal Y",
     "m_Position": {
         "x": -2109.000244140625,
-        "y": 519.9998779296875
+        "y": 519.999755859375
     }
 }
 
@@ -8179,6 +8088,29 @@
         "e32": 0.0,
         "e33": 1.0
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "078fa4d5929d48dcb37212e4fcd0aebb",
+    "m_Id": -985074803,
+    "m_DisplayName": "coef",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_coef",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -8404,6 +8336,31 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "09ba35a5f9f0439cbb794119c9d87a92",
+    "m_Id": 1,
+    "m_DisplayName": "Out_Vector4",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutVector4",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "09c9daa6231b4de481f875bd2fd6c88c",
     "m_Id": 2,
@@ -8532,42 +8489,6 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "0a3c7139a6ad4689ab369357f56bf2ce",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -955.000244140625,
-            "y": -3191.000244140625,
-            "width": 94.0001220703125,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "b32a40d1840e4c63a31e2952a0d46271"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "d77aab930a714b9699447f50d86ac852"
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "0a5c7c97680b4556b60fc0483d38b06f",
     "m_Group": {
         "m_Id": ""
@@ -8599,19 +8520,6 @@
     "m_Property": {
         "m_Id": "6e25cf21b19042e7809871a4bed799f9"
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
-    "m_ObjectId": "0a76152bac224852a00235391552cefd",
-    "m_Id": 0,
-    "m_DisplayName": "TopTexture",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_BareResource": false
 }
 
 {
@@ -8748,6 +8656,40 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "0b0cc6256e5e4d3588dde690c74af8e9",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Position",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "6afdc21139a64d7a9c7913a4399da808"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Position"
 }
 
 {
@@ -8965,6 +8907,24 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "0c3702fcf1474955897f2ff135bf9bd4",
+    "m_Id": 878772836,
+    "m_DisplayName": "texture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_texture",
+    "m_StageCapability": 2,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "0c47915380874718a432446cb1685b63",
     "m_Id": 3,
@@ -9039,42 +8999,6 @@
     },
     "m_Space": 4,
     "m_PositionSource": 0
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "0c61c03614594dff98ea43a3e62dce93",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -955.000244140625,
-            "y": -2667.000244140625,
-            "width": 109.00006103515625,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "402a402447944645b34d806ea9714da4"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "9934abfc36164c329a0480b30ef0c8eb"
-    }
 }
 
 {
@@ -9371,6 +9295,86 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
+    "m_ObjectId": "0d94147a14574512bd5a9eb0868dfd59",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "PLATEAU Lod 1 Triplanar Sub",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -970.0004272460938,
+            "y": -1486.0001220703125,
+            "width": 244.000244140625,
+            "height": 447.0001220703125
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c6b4ae40290f41de9b54646ef91b4d7a"
+        },
+        {
+            "m_Id": "cd6d904811744a55948af4419106a0e4"
+        },
+        {
+            "m_Id": "9a3533bb796a46d0b01668623ee8094e"
+        },
+        {
+            "m_Id": "bb7dd2de904c4d4396b5f967797d864f"
+        },
+        {
+            "m_Id": "dfa4cfeffdde4998885769e793f2ec32"
+        },
+        {
+            "m_Id": "28f9c0f742b047baa7dd423b92702fd6"
+        },
+        {
+            "m_Id": "369d65e6ed1a4c528fcb4f19a343e6ff"
+        },
+        {
+            "m_Id": "55320f4415ab47ba8a2feb1e246e0c82"
+        },
+        {
+            "m_Id": "f201ed3dbb664a97b7812d505b732824"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedSubGraph": "{\n    \"subGraph\": {\n        \"fileID\": -5475051401550479605,\n        \"guid\": \"dddc4c6b563945640a528c2298f6eb80\",\n        \"type\": 3\n    }\n}",
+    "m_PropertyGuids": [
+        "b533a582-e8cf-4db5-8f6d-b7baa6225076",
+        "df3c24b2-12cc-43d9-b0b9-51949afb0c22",
+        "33fa6efa-2a2f-4f4d-bce8-dde070878341",
+        "8c149f45-cd88-4128-9f63-45b4dfc231bc",
+        "39b918d5-46fa-4877-8288-2621ebc7ef05",
+        "079e4f5d-ec91-4bcc-bdd3-073d15ecc876",
+        "0fe1fc72-09ee-4a75-bb76-243e78518e14",
+        "b08c4047-354e-4cb9-a8fe-42a10399c54b"
+    ],
+    "m_PropertyIds": [
+        878772836,
+        716731476,
+        -571921639,
+        -985074803,
+        1426526534,
+        127769700,
+        1866388063,
+        380768930
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "0e1301e1ab994856b8d6a27e3f6cd516",
     "m_Id": 631652120,
@@ -9644,29 +9648,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "0fba8bbf08ad48c8941bf3be2039105a",
-    "m_Id": -985074803,
-    "m_DisplayName": "coef",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_coef",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
     "m_ObjectId": "0fd29486bf2449f5934e65c46e3ec15c",
     "m_Group": {
@@ -9829,43 +9810,23 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
-    "m_ObjectId": "104736848afd416f93350deeaac47a5d",
-    "m_Id": 878772836,
-    "m_DisplayName": "texture",
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "10a78ef473ef409a92f81647ec259f28",
+    "m_Id": -985074803,
+    "m_DisplayName": "coef",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "_texture",
-    "m_StageCapability": 2,
-    "m_BareResource": false,
-    "m_Texture": {
-        "m_SerializedTexture": "",
-        "m_Guid": ""
-    },
-    "m_DefaultType": 0
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
-    "m_ObjectId": "10caa5fa3bb4430da9b61d63480bb54f",
-    "m_Id": 1,
-    "m_DisplayName": "Out_Vector4",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "OutVector4",
+    "m_ShaderOutputName": "_coef",
     "m_StageCapability": 2,
     "m_Value": {
         "x": 0.0,
         "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
+        "z": 0.0
     },
     "m_DefaultValue": {
         "x": 0.0,
         "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
+        "z": 0.0
     },
     "m_Labels": []
 }
@@ -10135,42 +10096,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
-    "m_ObjectId": "11d17b32be9247d8afb1e081f815bcf8",
-    "m_Guid": {
-        "m_GuidSerialized": "47e8dcb4-552b-49cd-9f28-6e61a1ab0a92"
-    },
-    "promotedFromAssetID": "",
-    "promotedFromCategoryName": "",
-    "promotedOrdering": -1,
-    "m_Name": "BackTexture",
-    "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "BackTexture",
-    "m_DefaultReferenceName": "_BackTexture",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
-    "m_DismissedVersion": 0,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_PerRendererData": false,
-    "m_customAttributes": [],
-    "m_Value": {
-        "m_SerializedTexture": "",
-        "m_Guid": ""
-    },
-    "isMainTexture": false,
-    "useTilingAndOffset": false,
-    "useTexelSize": true,
-    "m_Modifiable": true,
-    "m_DefaultType": 0
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "128cfc970b7940b0b5594b6d613d4f1a",
     "m_Id": 0,
@@ -10236,6 +10161,65 @@
     },
     "m_Value": 0.0,
     "m_ConstIntMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "12ca4e9d324246b2b96041eef52c48df",
+    "m_Id": 0,
+    "m_DisplayName": "ZCoef",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "13036d9d6c104b7e933bdd072b141345",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1213.000244140625,
+            "y": -1848.9998779296875,
+            "width": 96.0,
+            "height": 33.9996337890625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "17214ae6077144e4a89417508c5b6ae6"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "bac640b190f64590a1e634b743694ff4"
+    }
 }
 
 {
@@ -10338,42 +10322,6 @@
         "w": 0.0
     },
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "13af348179844dddbff3630952fcd7a7",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -752.0000610351563,
-            "y": -1818.0001220703125,
-            "width": 108.9998779296875,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "fbaeee7c17944a4d992b6aef918114ad"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "00fead8eabd94d8fa536359fbdf70701"
-    }
 }
 
 {
@@ -10586,49 +10534,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.AddNode",
-    "m_ObjectId": "1522ba646a3644e3ab0093856fa2d6a0",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Add",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 139.9998321533203,
-            "y": -2349.00048828125,
-            "width": 208.00013732910157,
-            "height": 302.0003662109375
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "c2cd7e15495646dc9a896d91d5ec4163"
-        },
-        {
-            "m_Id": "de10f3ce888b4960a74753844658bce7"
-        },
-        {
-            "m_Id": "a4b7e03a94d94b07b5eaac5e137132bc"
-        }
-    ],
-    "synonyms": [
-        "addition",
-        "sum",
-        "plus"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "155b5542f7094728bc286ac73878e0e7",
     "m_Id": 0,
@@ -10805,6 +10710,31 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "15dfdec31d534bb0bf9763d8c386ae3a",
+    "m_Id": 1,
+    "m_DisplayName": "Out_Vector4",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutVector4",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "15eb1de851bd41fc886543e800d35f92",
     "m_Id": 439349965,
@@ -10931,25 +10861,18 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "17033b383fb249f4889f2b9f729b2b59",
-    "m_Id": 716731476,
-    "m_DisplayName": "normal",
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "16d279ca0fb748969b1f285cfc3e892a",
+    "m_Id": 127769700,
+    "m_DisplayName": "PixelsPerMeter",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "_normal",
+    "m_ShaderOutputName": "_PixelsPerMeter",
     "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": -1.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
 }
 
 {
@@ -11056,6 +10979,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "17214ae6077144e4a89417508c5b6ae6",
+    "m_Id": 0,
+    "m_DisplayName": "Min",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
+    "m_ObjectId": "176867340a1245d7b77788165466ef4b",
+    "m_Id": 0,
+    "m_DisplayName": "TopTexture",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "177791689a2e453891e9715b7bec5fa6",
     "m_Id": 1,
@@ -11147,86 +11106,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
-    "m_ObjectId": "18240f0837f64dee95ee4b225b4f27e0",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "PLATEAU Lod 1 Triplanar Sub",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -663.0001220703125,
-            "y": -3370.000244140625,
-            "width": 243.99996948242188,
-            "height": 447.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "eb7e9cc7835a4c37993339dbf9e16615"
-        },
-        {
-            "m_Id": "016d1fe6cc3c4a959fa33c01288ea3c0"
-        },
-        {
-            "m_Id": "293a7cf765d74651be5778635668d93c"
-        },
-        {
-            "m_Id": "1a94f48a93444bef80dc804a0b6c0540"
-        },
-        {
-            "m_Id": "4f488e90a2f341a3b646ffab674cbd75"
-        },
-        {
-            "m_Id": "9cc3ab9a0f8f4be09bc08b59186c9f4e"
-        },
-        {
-            "m_Id": "5fd2d66ff81c4b53a45e9313f969cee0"
-        },
-        {
-            "m_Id": "3d7f957030bc4ea8ad8e600ac9ed5415"
-        },
-        {
-            "m_Id": "6b3428a956944ae0aa4ac83f4d51c085"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedSubGraph": "{\n    \"subGraph\": {\n        \"fileID\": -5475051401550479605,\n        \"guid\": \"dddc4c6b563945640a528c2298f6eb80\",\n        \"type\": 3\n    }\n}",
-    "m_PropertyGuids": [
-        "b533a582-e8cf-4db5-8f6d-b7baa6225076",
-        "df3c24b2-12cc-43d9-b0b9-51949afb0c22",
-        "33fa6efa-2a2f-4f4d-bce8-dde070878341",
-        "8c149f45-cd88-4128-9f63-45b4dfc231bc",
-        "39b918d5-46fa-4877-8288-2621ebc7ef05",
-        "079e4f5d-ec91-4bcc-bdd3-073d15ecc876",
-        "0fe1fc72-09ee-4a75-bb76-243e78518e14",
-        "b08c4047-354e-4cb9-a8fe-42a10399c54b"
-    ],
-    "m_PropertyIds": [
-        878772836,
-        716731476,
-        -571921639,
-        -985074803,
-        1426526534,
-        127769700,
-        1866388063,
-        380768930
-    ],
-    "m_Dropdowns": [],
-    "m_DropdownSelectedEntries": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "1827cecd14784ee0a3205d251f5d547b",
     "m_Id": 1,
@@ -11272,6 +11151,22 @@
         "z": 0.0,
         "w": 0.0
     },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "1890d789471f486cab28f03142e266ac",
+    "m_Id": 0,
+    "m_DisplayName": "Tile",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
     "m_LiteralMode": false
 }
 
@@ -11360,6 +11255,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "18f1c67e7ffd4b209bcd96a342f5425c",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1331.0003662109375,
+            "y": -2720.0,
+            "width": 96.0001220703125,
+            "height": 33.999755859375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "b4e18a6f8c534f89ae2a3ca59d6e6059"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "bac640b190f64590a1e634b743694ff4"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "190e8a46693e4cf7b52f353929c63d3e",
     "m_Id": 1,
@@ -11372,6 +11303,42 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "191796285eed47bb9e68132f2bd50588",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1165.000244140625,
+            "y": -1187.0001220703125,
+            "width": 154.0,
+            "height": 34.0001220703125
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "e72991c17f83490596744baa9c0c9434"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "36e132d8adbe43bfb2803632ab726ded"
+    }
 }
 
 {
@@ -11561,6 +11528,31 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "1978ebc4e2194917adca68b6ac05ed97",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "19c5c09b13be4c839abf030a5fd3be37",
     "m_Id": 0,
     "m_DisplayName": "A",
@@ -11655,88 +11647,6 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "1a884bcb62d946eaa4735e207e490f2f",
-    "m_Id": 0,
-    "m_DisplayName": "Tile",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "1a94f48a93444bef80dc804a0b6c0540",
-    "m_Id": -985074803,
-    "m_DisplayName": "coef",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_coef",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.AddNode",
-    "m_ObjectId": "1b1558d4a4724fcfbaecbe742bd0945c",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Add",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -194.0001983642578,
-            "y": -2017.000244140625,
-            "width": 208.00013732910157,
-            "height": 302.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "bdf534d3842a4fd59a566be7622133e8"
-        },
-        {
-            "m_Id": "43243a572c394f54ad0e0fd836d57689"
-        },
-        {
-            "m_Id": "b931bae2ee7d47e39eb653cdca650f0d"
-        }
-    ],
-    "synonyms": [
-        "addition",
-        "sum",
-        "plus"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    }
 }
 
 {
@@ -12451,50 +12361,6 @@
 }
 
 {
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
-    "m_ObjectId": "1e81c5d7f04a4ba9bfccbbb370fec9a7",
-    "m_Guid": {
-        "m_GuidSerialized": "cb27733c-4197-4331-bd77-6803d8cbe65c"
-    },
-    "promotedFromAssetID": "",
-    "promotedFromCategoryName": "",
-    "promotedOrdering": -1,
-    "m_Name": "PixelsPerMeter",
-    "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "PixelsPerMeter",
-    "m_DefaultReferenceName": "_PixelsPerMeter",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
-    "m_DismissedVersion": 0,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_PerRendererData": false,
-    "m_customAttributes": [],
-    "m_Value": 1.0,
-    "m_FloatType": 0,
-    "m_LiteralFloatMode": false,
-    "m_RangeValues": {
-        "x": 0.0,
-        "y": 1.0
-    },
-    "m_SliderType": 0,
-    "m_SliderPower": 3.0,
-    "m_EnumType": 0,
-    "m_CSharpEnumString": "",
-    "m_EnumNames": [
-        "Default"
-    ],
-    "m_EnumValues": [
-        0
-    ]
-}
-
-{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "1eb63a9f59444a40a49667056941d9a0",
@@ -12994,6 +12860,31 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "225dbe96f1fc492191395ef947600f53",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "2267dcb19dec46daaf381ce249c7b617",
     "m_Id": -1433863329,
@@ -13362,6 +13253,19 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
+    "m_ObjectId": "246d1274bf114970bc527584f994f2a9",
+    "m_Id": 0,
+    "m_DisplayName": "RightTexture",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "2476c6155f98416ca8179fda915089d0",
     "m_Group": {
@@ -13503,29 +13407,6 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "25182fc0e1be46edb89b3b97745de1b8",
-    "m_Id": 1866388063,
-    "m_DisplayName": "a",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_a",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": -1.0,
-        "y": 1.0,
-        "z": -1.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -13752,17 +13633,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.GroupData",
-    "m_ObjectId": "268aebd00d0b4e74921a871f08492592",
-    "m_Title": "Lod1Triplanar",
-    "m_Position": {
-        "x": -1089.9998779296875,
-        "y": -3428.999755859375
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.RedirectNodeData",
     "m_ObjectId": "26aeccfd10db4794b844e943a7dd332c",
     "m_Group": {
@@ -13811,6 +13681,42 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
+    "m_ObjectId": "26f5377eeaca4c1198f8eaed1ebdf4cb",
+    "m_Guid": {
+        "m_GuidSerialized": "af2781b2-3e32-4f6f-87d6-4b83c001caf4"
+    },
+    "promotedFromAssetID": "",
+    "promotedFromCategoryName": "",
+    "promotedOrdering": -1,
+    "m_Name": "RightTexture",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "RightTexture",
+    "m_DefaultReferenceName": "_RightTexture",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_PerRendererData": false,
+    "m_customAttributes": [],
+    "m_Value": {
+        "m_SerializedTexture": "",
+        "m_Guid": ""
+    },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
+    "useTexelSize": true,
+    "m_Modifiable": true,
+    "m_DefaultType": 0
 }
 
 {
@@ -13903,6 +13809,31 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "27939196d21d4f2693f811a654043d73",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "28476b795f78453bb1b840298ef33110",
     "m_Id": 2,
@@ -13932,6 +13863,22 @@
     "m_Hidden": false,
     "m_ShaderOutputName": "Out",
     "m_StageCapability": 3
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "28f9c0f742b047baa7dd423b92702fd6",
+    "m_Id": 127769700,
+    "m_DisplayName": "PixelsPerMeter",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_PixelsPerMeter",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
 }
 
 {
@@ -14005,29 +13952,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "293a7cf765d74651be5778635668d93c",
-    "m_Id": -571921639,
-    "m_DisplayName": "origin",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_origin",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "29930c6d576446a9be8a0cae86d0efb0",
     "m_Id": 0,
@@ -14061,6 +13985,65 @@
     "m_Hidden": false,
     "m_ShaderOutputName": "Out",
     "m_StageCapability": 3
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "29ce046422b4421784589d3161022b52",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1133.0003662109375,
+            "y": -1307.0,
+            "width": 109.0001220703125,
+            "height": 33.9996337890625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "12ca4e9d324246b2b96041eef52c48df"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "631b2e44385843b1b5e2e29fb91a366f"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "29ef518d054947948207c3dad6aa5cb5",
+    "m_Id": 0,
+    "m_DisplayName": "Min",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -14677,6 +14660,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "2c9449e29a754964b5d5280d555b3607",
+    "m_Id": -571921639,
+    "m_DisplayName": "origin",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_origin",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "2c9792bd6c4e455c9692eafc1fe5c6be",
     "m_Id": 1,
@@ -14721,29 +14727,6 @@
         "e32": 0.0,
         "e33": 1.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "2cb84165d5c541909bd6be1d0a44e441",
-    "m_Id": 0,
-    "m_DisplayName": "Min",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -14797,48 +14780,6 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
-    "m_ObjectId": "2d9ffd75203e4c8fa500dee8a21e5619",
-    "m_Name": "Lod1Triplanar",
-    "m_ChildObjectList": [
-        {
-            "m_Id": "2f0fc2f20ea54732a65ea368672ea06c"
-        },
-        {
-            "m_Id": "a131527a1e2f4ee08b1be704ee20ee5b"
-        },
-        {
-            "m_Id": "9934abfc36164c329a0480b30ef0c8eb"
-        },
-        {
-            "m_Id": "e26a80b03d614a13999c3fa38b99a9b2"
-        },
-        {
-            "m_Id": "00fead8eabd94d8fa536359fbdf70701"
-        },
-        {
-            "m_Id": "04052d05f38847259e99e9759f7a5455"
-        },
-        {
-            "m_Id": "d40b57b8ad414fcfa8dc645697ce0930"
-        },
-        {
-            "m_Id": "e665594047ea42ec9cce2355de477c43"
-        },
-        {
-            "m_Id": "11d17b32be9247d8afb1e081f815bcf8"
-        },
-        {
-            "m_Id": "715b69dbc32a4aefa1890521ce28bc66"
-        },
-        {
-            "m_Id": "1e81c5d7f04a4ba9bfccbbb370fec9a7"
-        }
-    ]
 }
 
 {
@@ -14925,42 +14866,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "2e118fc47d494e5ca5bb7b16d05c7987",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -766.0001220703125,
-            "y": -1930.000244140625,
-            "width": 150.00006103515626,
-            "height": 33.9998779296875
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "3265e4bc355d45fe8dab0fe5d0990028"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "715b69dbc32a4aefa1890521ce28bc66"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "2e1a6099d7514add8f97cf4634e4e9a2",
     "m_Id": 2,
@@ -14978,31 +14883,6 @@
         "y": 1.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "2e3d89b57a4f4a39b35d31a691b2548d",
-    "m_Id": 0,
-    "m_DisplayName": "A",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "A",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_LiteralMode": false
 }
 
 {
@@ -15079,39 +14959,6 @@
         "w": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector3ShaderProperty",
-    "m_ObjectId": "2f0fc2f20ea54732a65ea368672ea06c",
-    "m_Guid": {
-        "m_GuidSerialized": "0095d0dc-8dba-4ed6-b666-1ad955d9812a"
-    },
-    "promotedFromAssetID": "",
-    "promotedFromCategoryName": "",
-    "promotedOrdering": -1,
-    "m_Name": "Min",
-    "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "Min",
-    "m_DefaultReferenceName": "_Min",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
-    "m_DismissedVersion": 0,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_PerRendererData": false,
-    "m_customAttributes": [],
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
 }
 
 {
@@ -15289,6 +15136,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "3078f26400094bf4a6f8875fa3c71deb",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1192.0001220703125,
+            "y": -2121.0,
+            "width": 153.9998779296875,
+            "height": 33.999755859375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "ab1280fc56244582a91f3644045ebfde"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "36e132d8adbe43bfb2803632ab726ded"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
     "m_ObjectId": "3085a1175bd346c5bfe363fdad34cd23",
     "m_Group": {
@@ -15328,22 +15211,6 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "30bbc20e887f46f5b4c4f9f7e01699a2",
-    "m_Id": 127769700,
-    "m_DisplayName": "PixelsPerMeter",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_PixelsPerMeter",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
 }
 
 {
@@ -15564,19 +15431,6 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
-    "m_ObjectId": "3265e4bc355d45fe8dab0fe5d0990028",
-    "m_Id": 0,
-    "m_DisplayName": "FrontTexture",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_BareResource": false
 }
 
 {
@@ -16023,6 +15877,48 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "351bb73335a44d568cf12d62be84c501",
+    "m_Name": "Lod1Triplanar",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "bac640b190f64590a1e634b743694ff4"
+        },
+        {
+            "m_Id": "dc022c39e6bb4ac8afc5ea58baa21213"
+        },
+        {
+            "m_Id": "a2a8a714e6d843c4ae8d0888b912da24"
+        },
+        {
+            "m_Id": "75fb5b24a9724ea1b675131c23522d13"
+        },
+        {
+            "m_Id": "631b2e44385843b1b5e2e29fb91a366f"
+        },
+        {
+            "m_Id": "647a74e6acc74647aff2344abb5e068f"
+        },
+        {
+            "m_Id": "70d3c3d92c2a46f0a90c8ce6d51ade25"
+        },
+        {
+            "m_Id": "ac503bef496344ad8b9dfb5bbb213f9b"
+        },
+        {
+            "m_Id": "26f5377eeaca4c1198f8eaed1ebdf4cb"
+        },
+        {
+            "m_Id": "059fefe3c6cc4f79a88d71e70088f647"
+        },
+        {
+            "m_Id": "36e132d8adbe43bfb2803632ab726ded"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.AddNode",
     "m_ObjectId": "353decbdb9b0495994796fd0c98b1843",
     "m_Group": {
@@ -16126,6 +16022,63 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "365ed0300ee5452eb8a452da8d91f932",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Tangent",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "62ff9c5715f94fa4962a4474f8c105c7"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Tangent"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "369d65e6ed1a4c528fcb4f19a343e6ff",
+    "m_Id": 1866388063,
+    "m_DisplayName": "a",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_a",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "36b0658b8d1146b3a08c34374910e6be",
     "m_Id": 1,
@@ -16147,6 +16100,42 @@
         "w": 0.0
     },
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "36b29c9b6e324b8da8e2f4c33067a691",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1133.0003662109375,
+            "y": -2182.0,
+            "width": 94.000244140625,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "43fe85ca84934aedb938a69b119fc837"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "d77aab930a714b9699447f50d86ac852"
+    }
 }
 
 {
@@ -16195,6 +16184,50 @@
         "e32": 0.0,
         "e33": 1.0
     }
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "36e132d8adbe43bfb2803632ab726ded",
+    "m_Guid": {
+        "m_GuidSerialized": "7e13286d-9194-4261-8424-a64a5b3b66a0"
+    },
+    "promotedFromAssetID": "",
+    "promotedFromCategoryName": "",
+    "promotedOrdering": -1,
+    "m_Name": "PixelsPerMeter",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "PixelsPerMeter",
+    "m_DefaultReferenceName": "_PixelsPerMeter",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_PerRendererData": false,
+    "m_customAttributes": [],
+    "m_Value": 1.0,
+    "m_FloatType": 0,
+    "m_LiteralFloatMode": false,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    },
+    "m_SliderType": 0,
+    "m_SliderPower": 3.0,
+    "m_EnumType": 0,
+    "m_CSharpEnumString": "",
+    "m_EnumNames": [
+        "Default"
+    ],
+    "m_EnumValues": [
+        0
+    ]
 }
 
 {
@@ -16281,6 +16314,42 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "SurfaceDescription.Occlusion"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "376db249a4c2409499bd05bbf72e4eb3",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1193.0001220703125,
+            "y": -2536.000244140625,
+            "width": 154.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "e770e729f78546728203d93dc2fdfcbd"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "36e132d8adbe43bfb2803632ab726ded"
+    }
 }
 
 {
@@ -16527,22 +16596,6 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "39d84ea056bb4ec3955fd5eb6cb03d5b",
-    "m_Id": 0,
-    "m_DisplayName": "PixelsPerMeter",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
 }
 
 {
@@ -16982,29 +17035,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "3d7f957030bc4ea8ad8e600ac9ed5415",
-    "m_Id": 380768930,
-    "m_DisplayName": "b",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_b",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.ContrastNode",
     "m_ObjectId": "3d80ba1b44d045dd9ee937b68cbdf1af",
     "m_Group": {
@@ -17072,29 +17102,6 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "3e682294d39c485a977ef8121d6cdcf3",
-    "m_Id": 716731476,
-    "m_DisplayName": "normal",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_normal",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 1.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -17283,29 +17290,6 @@
     "m_DefaultValue": {
         "x": 0.0,
         "y": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "402a402447944645b34d806ea9714da4",
-    "m_Id": 0,
-    "m_DisplayName": "XCoef",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
     },
     "m_Labels": []
 }
@@ -17611,6 +17595,49 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AddNode",
+    "m_ObjectId": "416876399b8f4fadbe6412102b5ea3dc",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Add",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -576.000244140625,
+            "y": -2014.0001220703125,
+            "width": 207.9998779296875,
+            "height": 302.0001220703125
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "65d9ec679483466ca3dea2f177da2744"
+        },
+        {
+            "m_Id": "7a82549d431949ed92310e1e9a337cb6"
+        },
+        {
+            "m_Id": "dec9ac56f8634a8bac9cde7315f0fa89"
+        }
+    ],
+    "synonyms": [
+        "addition",
+        "sum",
+        "plus"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlockNode",
     "m_ObjectId": "41adb7215e284b0d997c39b9b052a9e8",
     "m_Group": {
@@ -17682,42 +17709,6 @@
     },
     "m_Keyword": {
         "m_Id": "0b330496ad4f431c98bb3b70781ddb5c"
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "41d04f2bd87646178231e4706a7b853e",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -811.0001220703125,
-            "y": -2539.000244140625,
-            "width": 153.99993896484376,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "7f04b08b00a84f09ace2f52f80d96f9c"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "1e81c5d7f04a4ba9bfccbbb370fec9a7"
     }
 }
 
@@ -17923,22 +17914,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "42a4a326ef6044bd8edfe0c6a1242aa0",
-    "m_Id": 0,
-    "m_DisplayName": "PixelsPerMeter",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "42dce5fa4f79469fb55b73dfc9347ccb",
     "m_Id": 1,
@@ -17971,31 +17946,6 @@
     "m_SlotType": 0,
     "m_Hidden": false,
     "m_ShaderOutputName": "A",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "43243a572c394f54ad0e0fd836d57689",
-    "m_Id": 1,
-    "m_DisplayName": "B",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "B",
     "m_StageCapability": 3,
     "m_Value": {
         "x": 0.0,
@@ -18084,6 +18034,22 @@
         "z": 0.0,
         "w": 0.0
     },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "43fe85ca84934aedb938a69b119fc837",
+    "m_Id": 0,
+    "m_DisplayName": "Tile",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
     "m_LiteralMode": false
 }
 
@@ -18419,6 +18385,104 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "463298733e304e8c9aa04a9636255d51",
+    "m_Id": 878772836,
+    "m_DisplayName": "texture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_texture",
+    "m_StageCapability": 2,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
+    "m_ObjectId": "46d368d78872458097681745a2a7266c",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "PLATEAU Lod 1 Triplanar Sub",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1045.0003662109375,
+            "y": -3367.0,
+            "width": 244.000244140625,
+            "height": 447.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "463298733e304e8c9aa04a9636255d51"
+        },
+        {
+            "m_Id": "f6016fc1cc994c02abf133a689d17d3e"
+        },
+        {
+            "m_Id": "2c9449e29a754964b5d5280d555b3607"
+        },
+        {
+            "m_Id": "078fa4d5929d48dcb37212e4fcd0aebb"
+        },
+        {
+            "m_Id": "f803068728434e6a988ee74dae3b8d02"
+        },
+        {
+            "m_Id": "83d272e809954f6986daeea8fa17b29e"
+        },
+        {
+            "m_Id": "d7a1e66f03f14775ac9503a4fb83a600"
+        },
+        {
+            "m_Id": "4734fd1aa350433d9a8c36d9f599ecab"
+        },
+        {
+            "m_Id": "09ba35a5f9f0439cbb794119c9d87a92"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedSubGraph": "{\n    \"subGraph\": {\n        \"fileID\": -5475051401550479605,\n        \"guid\": \"dddc4c6b563945640a528c2298f6eb80\",\n        \"type\": 3\n    }\n}",
+    "m_PropertyGuids": [
+        "b533a582-e8cf-4db5-8f6d-b7baa6225076",
+        "df3c24b2-12cc-43d9-b0b9-51949afb0c22",
+        "33fa6efa-2a2f-4f4d-bce8-dde070878341",
+        "8c149f45-cd88-4128-9f63-45b4dfc231bc",
+        "39b918d5-46fa-4877-8288-2621ebc7ef05",
+        "079e4f5d-ec91-4bcc-bdd3-073d15ecc876",
+        "0fe1fc72-09ee-4a75-bb76-243e78518e14",
+        "b08c4047-354e-4cb9-a8fe-42a10399c54b"
+    ],
+    "m_PropertyIds": [
+        878772836,
+        716731476,
+        -571921639,
+        -985074803,
+        1426526534,
+        127769700,
+        1866388063,
+        380768930
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
     "m_ObjectId": "46dc2972d1374f58a3d95413bed60ab5",
     "m_Id": 0,
@@ -18484,43 +18548,30 @@
     ],
     "m_CustomEditorGUI": "",
     "m_SupportVFX": false,
-    "m_SupportComputeForVertexSetup": false
+    "m_SupportLineRendering": false
 }
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "477d794df48540e6915048d32fb65c4b",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "4734fd1aa350433d9a8c36d9f599ecab",
+    "m_Id": 380768930,
+    "m_DisplayName": "b",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_b",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
     },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -751.0001831054688,
-            "y": -2185.000244140625,
-            "width": 94.0,
-            "height": 34.0
-        }
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
     },
-    "m_Slots": [
-        {
-            "m_Id": "8685dc7316ce4916887514b0a30a74b6"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "d77aab930a714b9699447f50d86ac852"
-    }
+    "m_Labels": []
 }
 
 {
@@ -18562,6 +18613,29 @@
         "w": 0.0
     },
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "484ca62c63934f6583a2d74c704463d7",
+    "m_Id": -985074803,
+    "m_DisplayName": "coef",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_coef",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -18937,29 +19011,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "49fa8b7595a84f67ad055d190540e914",
-    "m_Id": 716731476,
-    "m_DisplayName": "normal",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_normal",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": -1.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "4a1b725499cf4f9db71da5519ce9d167",
     "m_Id": 1,
@@ -19018,42 +19069,6 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "4a52a9ac6ea541f8ae6c249da5746304",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -822.0001831054688,
-            "y": -3349.00048828125,
-            "width": 142.00006103515626,
-            "height": 34.000244140625
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "0a76152bac224852a00235391552cefd"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "e665594047ea42ec9cce2355de477c43"
-    }
 }
 
 {
@@ -19168,47 +19183,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
-    "m_ObjectId": "4c5f0ad44e464738b6d4104810118365",
-    "m_Id": 1,
-    "m_DisplayName": "Out_Vector4",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "OutVector4",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "4c7912f07d6e48ce9968aac53413ad12",
-    "m_Id": 0,
-    "m_DisplayName": "PixelsPerMeter",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "4c83b890332546089d8d1bf7dc90b0e1",
     "m_Id": 0,
@@ -19246,6 +19220,29 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "4d07ef0264bf45099011c3933127c9c7",
+    "m_Id": 0,
+    "m_DisplayName": "XCoef",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -19300,6 +19297,29 @@
     },
     "m_Width": 208.0,
     "m_Height": 208.0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "4d69549270bc45c7b1972d78c86456c8",
+    "m_Id": 0,
+    "m_DisplayName": "ZCoef",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -19704,22 +19724,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "4f488e90a2f341a3b646ffab674cbd75",
-    "m_Id": 1426526534,
-    "m_DisplayName": "tile",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_tile",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
     "m_ObjectId": "4f7091fdfa2144a68fa46ecc28b71088",
     "m_Id": 0,
@@ -19917,86 +19921,6 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
-    "m_ObjectId": "50ae29548026417a8da5995e89c7320b",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "PLATEAU Lod 1 Triplanar Sub",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -614.0001831054688,
-            "y": -2801.000244140625,
-            "width": 243.99993896484376,
-            "height": 447.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "104736848afd416f93350deeaac47a5d"
-        },
-        {
-            "m_Id": "52b751f35b574a24af9edac7c754eda0"
-        },
-        {
-            "m_Id": "ea7db4dcfb274a349f12d19fe1bf0633"
-        },
-        {
-            "m_Id": "fec563ab25b548d6b4bbc69b1dcfa3d8"
-        },
-        {
-            "m_Id": "af1977dce9194432b44cda1aed4394e9"
-        },
-        {
-            "m_Id": "c112b199308242f79731994bdf462ecb"
-        },
-        {
-            "m_Id": "25182fc0e1be46edb89b3b97745de1b8"
-        },
-        {
-            "m_Id": "73a67d525e904e13a72304265823bc66"
-        },
-        {
-            "m_Id": "d0bd5d64b4f54d98b2cc3794ab4aedbf"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedSubGraph": "{\n    \"subGraph\": {\n        \"fileID\": -5475051401550479605,\n        \"guid\": \"dddc4c6b563945640a528c2298f6eb80\",\n        \"type\": 3\n    }\n}",
-    "m_PropertyGuids": [
-        "b533a582-e8cf-4db5-8f6d-b7baa6225076",
-        "df3c24b2-12cc-43d9-b0b9-51949afb0c22",
-        "33fa6efa-2a2f-4f4d-bce8-dde070878341",
-        "8c149f45-cd88-4128-9f63-45b4dfc231bc",
-        "39b918d5-46fa-4877-8288-2621ebc7ef05",
-        "079e4f5d-ec91-4bcc-bdd3-073d15ecc876",
-        "0fe1fc72-09ee-4a75-bb76-243e78518e14",
-        "b08c4047-354e-4cb9-a8fe-42a10399c54b"
-    ],
-    "m_PropertyIds": [
-        878772836,
-        716731476,
-        -571921639,
-        -985074803,
-        1426526534,
-        127769700,
-        1866388063,
-        380768930
-    ],
-    "m_Dropdowns": [],
-    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -20506,52 +20430,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "52b751f35b574a24af9edac7c754eda0",
-    "m_Id": 716731476,
-    "m_DisplayName": "normal",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_normal",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 1.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "53394faf8fac4da48aea6c3788ffd732",
-    "m_Id": -571921639,
-    "m_DisplayName": "origin",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_origin",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "538b5327c13f467ba03a7e55ce97295b",
     "m_Id": 0,
@@ -20564,6 +20442,29 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "53cc199980ca48789ecb79f66a166f7a",
+    "m_Id": 1866388063,
+    "m_DisplayName": "a",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_a",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -20704,6 +20605,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "55320f4415ab47ba8a2feb1e246e0c82",
+    "m_Id": 380768930,
+    "m_DisplayName": "b",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_b",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "553a5c618c7d4f079222394d8e0b578a",
     "m_Id": 0,
@@ -20830,6 +20754,31 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "561c8042ca2144968a0d22017067234a",
+    "m_Id": 0,
+    "m_DisplayName": "",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "5639710283f54f4d9887aa63d2f3a6e6",
     "m_Id": 0,
     "m_DisplayName": "In",
@@ -20850,42 +20799,6 @@
         "w": 0.0
     },
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "564aefb1013746cc93a256ce3478f4af",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -751.0001831054688,
-            "y": -1310.000244140625,
-            "width": 109.00006103515625,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "dce2a14f6c974633aaa9c43b4f2f3f04"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "00fead8eabd94d8fa536359fbdf70701"
-    }
 }
 
 {
@@ -20911,42 +20824,6 @@
         "w": 0.0
     },
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "56dcecd7f8d247f5bb47c9f15280ba58",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -995.0001220703125,
-            "y": -2615.000244140625,
-            "width": 93.99993896484375,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "1a884bcb62d946eaa4735e207e490f2f"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "d77aab930a714b9699447f50d86ac852"
-    }
 }
 
 {
@@ -21143,42 +21020,6 @@
         "w": 0.0
     },
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "57e24ad789254e5a9b28353369b81644",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -831.000244140625,
-            "y": -1852.0001220703125,
-            "width": 96.0001220703125,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "2cb84165d5c541909bd6be1d0a44e441"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "2f0fc2f20ea54732a65ea368672ea06c"
-    }
 }
 
 {
@@ -21448,6 +21289,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "586131ec819b4a389b5f2ea0a7df7af9",
+    "m_Id": 0,
+    "m_DisplayName": "Min",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "5868418b1e234722b58caa0185b0412c",
     "m_Id": 0,
@@ -21633,6 +21497,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "59eba968bf064d2ea79d4b14ba8eb81d",
+    "m_Id": 0,
+    "m_DisplayName": "Min",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "59f07bd0875549668c8d61a979a5714c",
     "m_Id": 3,
@@ -21699,6 +21586,49 @@
         "m_Guid": ""
     },
     "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AddNode",
+    "m_ObjectId": "5aa997c574014e11b576ad4ec1c94c35",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Add",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 52.999752044677737,
+            "y": -2763.000244140625,
+            "width": 207.99984741210938,
+            "height": 302.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "667259f07bf14f99ba33d60269bcc52f"
+        },
+        {
+            "m_Id": "cc3d042ccf964875b4937fc9fcdb6fab"
+        },
+        {
+            "m_Id": "27939196d21d4f2693f811a654043d73"
+        }
+    ],
+    "synonyms": [
+        "addition",
+        "sum",
+        "plus"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -21771,49 +21701,6 @@
         "e31": 0.0,
         "e32": 0.0,
         "e33": 1.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.AddNode",
-    "m_ObjectId": "5b1da221343f450d93f75ba8776cb5a8",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Add",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -227.00022888183595,
-            "y": -2539.000244140625,
-            "width": 208.00015258789063,
-            "height": 302.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "2e3d89b57a4f4a39b35d31a691b2548d"
-        },
-        {
-            "m_Id": "5fe5278514b54443a5b812e15c5ed9b0"
-        },
-        {
-            "m_Id": "0692e4a05d764cf49cc3757b0d837698"
-        }
-    ],
-    "synonyms": [
-        "addition",
-        "sum",
-        "plus"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
     }
 }
 
@@ -21900,25 +21787,43 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "5be9bb66f16240ccab2c816f5f7977dd",
+    "m_Id": 878772836,
+    "m_DisplayName": "texture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_texture",
+    "m_StageCapability": 2,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "5bca8e26c69a4224a6f329cbe9e4ae68",
+    "m_ObjectId": "5c2aec49aec34c24a3d3c407bf81c603",
     "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
     },
     "m_Name": "Property",
     "m_DrawState": {
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -911.0001831054688,
-            "y": -2796.000244140625,
-            "width": 143.00006103515626,
-            "height": 34.0
+            "x": -1264.0,
+            "y": -3115.000244140625,
+            "width": 154.0,
+            "height": 34.000244140625
         }
     },
     "m_Slots": [
         {
-            "m_Id": "b29ed0ba1cf34f4dbf6864a0c311006b"
+            "m_Id": "958544a686ee421983538d79ab04c724"
         }
     ],
     "synonyms": [],
@@ -21930,7 +21835,7 @@
         "m_SerializableColors": []
     },
     "m_Property": {
-        "m_Id": "d40b57b8ad414fcfa8dc645697ce0930"
+        "m_Id": "36e132d8adbe43bfb2803632ab726ded"
     }
 }
 
@@ -22256,82 +22161,10 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "5d9b6944697a4c66887818ca156362c3",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -760.0001831054688,
-            "y": -2289.000244140625,
-            "width": 95.99993896484375,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "96b456ed911e4f199ef02f4bba4d1a72"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "2f0fc2f20ea54732a65ea368672ea06c"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
     "m_ObjectId": "5da25e58ac214769b6e57ac6625e7b81",
     "m_Id": 2,
     "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
-    "m_ObjectId": "5da36e3b039c479db47217579c40cdfb",
-    "m_Id": 0,
-    "m_DisplayName": "RightTexture",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_BareResource": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "5dc4f9def3724487bbd4edcecf128b98",
-    "m_Id": 0,
-    "m_DisplayName": "Max",
     "m_SlotType": 1,
     "m_Hidden": false,
     "m_ShaderOutputName": "Out",
@@ -22712,6 +22545,31 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "5f9200347eba468980183968b8c2706d",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "5f9a319e42e94fa98f18b39e0aff798c",
     "m_Id": 3,
@@ -22746,29 +22604,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "5fd2d66ff81c4b53a45e9313f969cee0",
-    "m_Id": 1866388063,
-    "m_DisplayName": "a",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_a",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 1.0,
-        "y": 1.0,
-        "z": 1.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "5fd874884b62432d80146d4c4c7b23ca",
     "m_Id": 0,
@@ -22794,40 +22629,25 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "5fe5278514b54443a5b812e15c5ed9b0",
-    "m_Id": 1,
-    "m_DisplayName": "B",
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "5fe96ec219374fceb7e13e722eb478f4",
+    "m_Id": 716731476,
+    "m_DisplayName": "normal",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "B",
-    "m_StageCapability": 3,
+    "m_ShaderOutputName": "_normal",
+    "m_StageCapability": 2,
     "m_Value": {
-        "x": 0.0,
+        "x": -1.0,
         "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
+        "z": 0.0
     },
     "m_DefaultValue": {
         "x": 0.0,
         "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
+        "z": 0.0
     },
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
-    "m_ObjectId": "601268365a4241319c8a61f6d05a7faf",
-    "m_Id": 0,
-    "m_DisplayName": "BackTexture",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_BareResource": false
+    "m_Labels": []
 }
 
 {
@@ -23122,6 +22942,63 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.TangentMaterialSlot",
+    "m_ObjectId": "62ff9c5715f94fa4962a4474f8c105c7",
+    "m_Id": 0,
+    "m_DisplayName": "Tangent",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Tangent",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector3ShaderProperty",
+    "m_ObjectId": "631b2e44385843b1b5e2e29fb91a366f",
+    "m_Guid": {
+        "m_GuidSerialized": "a00df48f-9675-4efb-9ec5-ad3ae4ad25ce"
+    },
+    "promotedFromAssetID": "",
+    "promotedFromCategoryName": "",
+    "promotedOrdering": -1,
+    "m_Name": "ZCoef",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "ZCoef",
+    "m_DefaultReferenceName": "_ZCoef",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_PerRendererData": false,
+    "m_customAttributes": [],
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
     "m_ObjectId": "632e9fb54bfb4dcfabe6c1faeea1467a",
     "m_Id": 0,
@@ -23247,22 +23124,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "63e3fb92aa61477790a1cf1521ed8106",
-    "m_Id": 1426526534,
-    "m_DisplayName": "tile",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_tile",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "63fbd328d82b437bbd6d5010825267da",
     "m_Id": 0,
@@ -23311,22 +23172,6 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "642820c0d656426ea601441e9a2f0715",
-    "m_Id": 127769700,
-    "m_DisplayName": "PixelsPerMeter",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_PixelsPerMeter",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "64780479c87e411fb3882c692f356135",
     "m_Id": 5,
     "m_DisplayName": "Blend_z",
@@ -23338,6 +23183,42 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
+    "m_ObjectId": "647a74e6acc74647aff2344abb5e068f",
+    "m_Guid": {
+        "m_GuidSerialized": "e8ed27de-a631-4d8e-9520-55c4946f35e6"
+    },
+    "promotedFromAssetID": "",
+    "promotedFromCategoryName": "",
+    "promotedOrdering": -1,
+    "m_Name": "FrontTexture",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "FrontTexture",
+    "m_DefaultReferenceName": "_FrontTexture",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_PerRendererData": false,
+    "m_customAttributes": [],
+    "m_Value": {
+        "m_SerializedTexture": "",
+        "m_Guid": ""
+    },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
+    "useTexelSize": true,
+    "m_Modifiable": true,
+    "m_DefaultType": 0
 }
 
 {
@@ -23399,38 +23280,27 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "64eafe7bdf424c40bb32f9759c2a1acd",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "64cdd4e868f54ea082a21ec99b37e224",
+    "m_Id": 1,
+    "m_DisplayName": "Out_Vector4",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutVector4",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -983.0001220703125,
-            "y": -1757.0,
-            "width": 153.99993896484376,
-            "height": 33.9998779296875
-        }
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     },
-    "m_Slots": [
-        {
-            "m_Id": "39d84ea056bb4ec3955fd5eb6cb03d5b"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "1e81c5d7f04a4ba9bfccbbb370fec9a7"
-    }
+    "m_Labels": []
 }
 
 {
@@ -23518,8 +23388,8 @@
     "m_ObjectId": "656155abed2648b6bf803e4d5394beca",
     "m_Title": "Fake GI",
     "m_Position": {
-        "x": 26.0,
-        "y": 3366.000244140625
+        "x": 25.999755859375,
+        "y": 3366.00048828125
     }
 }
 
@@ -23594,6 +23464,31 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "65d9ec679483466ca3dea2f177da2744",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "661d3e5bdb0e496fa71af5e83aa186bb",
     "m_Id": 1,
     "m_DisplayName": "B",
@@ -23625,6 +23520,31 @@
     "m_SlotType": 0,
     "m_Hidden": false,
     "m_ShaderOutputName": "T",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "667259f07bf14f99ba33d60269bcc52f",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
     "m_StageCapability": 3,
     "m_Value": {
         "x": 0.0,
@@ -23899,6 +23819,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "6784b08274c0441081b8f121246e30a8",
+    "m_Id": -985074803,
+    "m_DisplayName": "coef",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_coef",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PowerNode",
     "m_ObjectId": "67b615f56305405ea32327cd6f482c6a",
     "m_Group": {
@@ -24034,29 +23977,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "6850c00a45ee4533bd029fbed0066b48",
-    "m_Id": 0,
-    "m_DisplayName": "Min",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.RedirectNodeData",
     "m_ObjectId": "687dc119bd254988a51b77b8d332426e",
     "m_Group": {
@@ -24136,6 +24056,15 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalLitSubTarget",
+    "m_ObjectId": "6902cce589024d00a05b3ee5a3d364c7",
+    "m_WorkflowMode": 1,
+    "m_NormalDropOffSpace": 0,
+    "m_ClearCoat": false
 }
 
 {
@@ -24275,29 +24204,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "6a401ebdc3bd4578a8b071630640e860",
-    "m_Id": 0,
-    "m_DisplayName": "XCoef",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "6a65aad61c794a92a66257914193afb4",
     "m_Id": 2,
@@ -24401,6 +24307,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PositionMaterialSlot",
+    "m_ObjectId": "6afdc21139a64d7a9c7913a4399da808",
+    "m_Id": 0,
+    "m_DisplayName": "Position",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Position",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "6b07b86e38e34940bb64d93866470ed9",
     "m_Id": 0,
@@ -24434,31 +24364,6 @@
     "m_DefaultValue": 1.0,
     "m_Labels": [],
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
-    "m_ObjectId": "6b3428a956944ae0aa4ac83f4d51c085",
-    "m_Id": 1,
-    "m_DisplayName": "Out_Vector4",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "OutVector4",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -24607,27 +24512,36 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "6d20674749df43c9a6587288631967dc",
-    "m_Id": 1,
-    "m_DisplayName": "B",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "B",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "6d160b7b6cf440329f9c96c60bd320a0",
+    "m_Group": {
+        "m_Id": ""
     },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
+    "m_Name": "VertexDescription.Normal",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
     },
-    "m_LiteralMode": false
+    "m_Slots": [
+        {
+            "m_Id": "e6ac44addd7f4ba99830af48908783d4"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Normal"
 }
 
 {
@@ -25169,6 +25083,33 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.GroupData",
+    "m_ObjectId": "6f3455e5e11545ba83ddff692b6d5f55",
+    "m_Title": "Lod1Triplanar",
+    "m_Position": {
+        "x": -1472.0001220703125,
+        "y": -3426.000244140625
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "6f39f3fc1d4042b882718857cb85f864",
+    "m_Id": 1426526534,
+    "m_DisplayName": "tile",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_tile",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "6f54804875b5469d9ff9bfe177840e41",
     "m_Id": 0,
@@ -25272,24 +25213,24 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "70790f4f755c4f3db65cb140ab10c896",
+    "m_ObjectId": "707cf90768c64c20b77beae773e25ff9",
     "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
     },
     "m_Name": "Property",
     "m_DrawState": {
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1065.000244140625,
-            "y": -1660.0001220703125,
-            "width": 99.0001220703125,
-            "height": 34.0
+            "x": -1187.000244140625,
+            "y": -3222.0,
+            "width": 109.0001220703125,
+            "height": 33.999755859375
         }
     },
     "m_Slots": [
         {
-            "m_Id": "5dc4f9def3724487bbd4edcecf128b98"
+            "m_Id": "8396d722daac4577bf8c52bfc8aa81ee"
         }
     ],
     "synonyms": [],
@@ -25301,7 +25242,7 @@
         "m_SerializableColors": []
     },
     "m_Property": {
-        "m_Id": "a131527a1e2f4ee08b1be704ee20ee5b"
+        "m_Id": "75fb5b24a9724ea1b675131c23522d13"
     }
 }
 
@@ -25401,17 +25342,17 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
-    "m_ObjectId": "715b69dbc32a4aefa1890521ce28bc66",
+    "m_ObjectId": "70d3c3d92c2a46f0a90c8ce6d51ade25",
     "m_Guid": {
-        "m_GuidSerialized": "8501035b-aefa-415e-9409-dd47b1bd22e2"
+        "m_GuidSerialized": "64dc8fbe-97d6-48d7-8a63-efa5d22ccccb"
     },
     "promotedFromAssetID": "",
     "promotedFromCategoryName": "",
     "promotedOrdering": -1,
-    "m_Name": "FrontTexture",
+    "m_Name": "TopTexture",
     "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "FrontTexture",
-    "m_DefaultReferenceName": "_FrontTexture",
+    "m_RefNameGeneratedByDisplayName": "TopTexture",
+    "m_DefaultReferenceName": "_TopTexture",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
     "m_UseCustomSlotLabel": false,
@@ -25648,42 +25589,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "735f22a9ce9d479999868eefdd3b4a7b",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -736.0001831054688,
-            "y": -1254.0001220703125,
-            "width": 94.00006103515625,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "b0fb5366129041e18c10e758c61b0ff1"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "d77aab930a714b9699447f50d86ac852"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "7394df529e9f46e8928fed039e14f882",
     "m_Id": 2,
@@ -25705,52 +25610,6 @@
         "w": 0.0
     },
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "73a67d525e904e13a72304265823bc66",
-    "m_Id": 380768930,
-    "m_DisplayName": "b",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_b",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 1.0,
-        "y": 0.0,
-        "z": 1.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "74098d743d71422eb2a8606f9a93f405",
-    "m_Id": 1866388063,
-    "m_DisplayName": "a",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_a",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": -1.0,
-        "y": 1.0,
-        "z": -1.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -26063,6 +25922,39 @@
     "m_EnumValues": [
         0
     ]
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector3ShaderProperty",
+    "m_ObjectId": "75fb5b24a9724ea1b675131c23522d13",
+    "m_Guid": {
+        "m_GuidSerialized": "413115e5-fe1e-4bb4-af59-848fe4ea34b6"
+    },
+    "promotedFromAssetID": "",
+    "promotedFromCategoryName": "",
+    "promotedOrdering": -1,
+    "m_Name": "YCoef",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "YCoef",
+    "m_DefaultReferenceName": "_YCoef",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_PerRendererData": false,
+    "m_customAttributes": [],
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -26498,6 +26390,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.RedirectNodeData",
+    "m_ObjectId": "77ad06650cb24ee2afe26a48ff7b20ce",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Redirect Node",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 581.0000610351563,
+            "y": 494.0,
+            "width": 56.0,
+            "height": 24.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "561c8042ca2144968a0d22017067234a"
+        },
+        {
+            "m_Id": "d9755214b58f4cb2b751a4a69c86b7b1"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "780fb5f921ea4bceb205946be58dbeac",
     "m_Id": 0,
@@ -26528,7 +26456,7 @@
     "m_Title": "MaskByHeight",
     "m_Position": {
         "x": -2221.000244140625,
-        "y": 830.9999389648438
+        "y": 831.0
     }
 }
 
@@ -26784,17 +26712,26 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "7a5d67fed6c449429bb7c7a4ce492a24",
-    "m_Id": 0,
-    "m_DisplayName": "PixelsPerMeter",
-    "m_SlotType": 1,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "7a82549d431949ed92310e1e9a337cb6",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
+    "m_ShaderOutputName": "B",
     "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
     "m_LiteralMode": false
 }
 
@@ -26914,29 +26851,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "7b96b8ef186244fd9836405ca232e4b6",
-    "m_Id": -985074803,
-    "m_DisplayName": "coef",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_coef",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "7bc02d36e53b451999770a95196969ba",
     "m_Id": 2,
@@ -26949,42 +26863,6 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "7c1ec6bd2e4246eda00556ce896b9a01",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -783.0001220703125,
-            "y": -1190.000244140625,
-            "width": 153.99993896484376,
-            "height": 34.000244140625
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "7a5d67fed6c449429bb7c7a4ce492a24"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "1e81c5d7f04a4ba9bfccbbb370fec9a7"
-    }
 }
 
 {
@@ -27202,6 +27080,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "7d4f71e317294c948a9e2f051c882416",
+    "m_Id": 1866388063,
+    "m_DisplayName": "a",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_a",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": -1.0,
+        "y": 1.0,
+        "z": -1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "7dabe7a2f5294d25ad658b15b90f8055",
     "m_Id": 1,
@@ -27312,6 +27213,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "7e2cc32b239147529dc5c3cc6e779337",
+    "m_Id": 380768930,
+    "m_DisplayName": "b",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_b",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
     "m_ObjectId": "7ec07e472c3f463d958a098346f2db6f",
     "m_Id": 0,
@@ -27375,22 +27299,6 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "7f04b08b00a84f09ace2f52f80d96f9c",
-    "m_Id": 0,
-    "m_DisplayName": "PixelsPerMeter",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
 }
 
 {
@@ -27580,29 +27488,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "8029ef51ded24f589c07d9b5f538927b",
-    "m_Id": -985074803,
-    "m_DisplayName": "coef",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_coef",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "80487fa5d9124e3f88487848f4bec9f7",
     "m_Id": 1,
@@ -27640,86 +27525,6 @@
         "w": 0.0
     },
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
-    "m_ObjectId": "810938c97ec14208b380f758afdbd06c",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "PLATEAU Lod 1 Triplanar Sub",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -559.0000610351563,
-            "y": -1930.000244140625,
-            "width": 243.99996948242188,
-            "height": 447.0001220703125
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "8196032c5e254b5d8c3239133f7dadb6"
-        },
-        {
-            "m_Id": "3e682294d39c485a977ef8121d6cdcf3"
-        },
-        {
-            "m_Id": "edd948eca64349569bb13210ff9fa1a1"
-        },
-        {
-            "m_Id": "0fba8bbf08ad48c8941bf3be2039105a"
-        },
-        {
-            "m_Id": "f4a06e0a84b84a4baf54af17fdd2ff87"
-        },
-        {
-            "m_Id": "642820c0d656426ea601441e9a2f0715"
-        },
-        {
-            "m_Id": "74098d743d71422eb2a8606f9a93f405"
-        },
-        {
-            "m_Id": "d62433c722674d1482f19411eee798a9"
-        },
-        {
-            "m_Id": "990ac29263d744c9a3304838734c52e1"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedSubGraph": "{\n    \"subGraph\": {\n        \"fileID\": -5475051401550479605,\n        \"guid\": \"dddc4c6b563945640a528c2298f6eb80\",\n        \"type\": 3\n    }\n}",
-    "m_PropertyGuids": [
-        "b533a582-e8cf-4db5-8f6d-b7baa6225076",
-        "df3c24b2-12cc-43d9-b0b9-51949afb0c22",
-        "33fa6efa-2a2f-4f4d-bce8-dde070878341",
-        "8c149f45-cd88-4128-9f63-45b4dfc231bc",
-        "39b918d5-46fa-4877-8288-2621ebc7ef05",
-        "079e4f5d-ec91-4bcc-bdd3-073d15ecc876",
-        "0fe1fc72-09ee-4a75-bb76-243e78518e14",
-        "b08c4047-354e-4cb9-a8fe-42a10399c54b"
-    ],
-    "m_PropertyIds": [
-        878772836,
-        716731476,
-        -571921639,
-        -985074803,
-        1426526534,
-        127769700,
-        1866388063,
-        380768930
-    ],
-    "m_Dropdowns": [],
-    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -27876,24 +27681,6 @@
     "m_FunctionSource": "04f440ee1952d3644b7700d4d1cfe468",
     "m_FunctionSourceUsePragmas": true,
     "m_FunctionBody": "float3 rayDir = -viewDir;\r\nrayDir .z *= -1;\r\nfloat3 uvw = float3(frac(uv), -roomDepth + 1.0);\r\n\r\nfloat3 dist3 = (step(0.0, rayDir) - uvw) / rayDir;\r\nfloat dist = min(min(dist3.x, dist3.y), dist3.z); \r\n\r\nfloat3 rayHit = uvw + rayDir * dist;\r\nrayHit.z = (rayHit.z + roomDepth  - 1.0) / roomDepth ;\r\nfloat3 rayHitNormal = step(1.0 - 1e-3, abs(rayHit - 0.5) * 2.0);\r\n\r\nfloat3 finalRGB = float3(dist, dist, dist) * 0.5;\r\n\r\nfloat  tileX = 1.0/floor(roomAtlasColumns);\r\nfloat  tileY = 1.0/floor(roomAtlasRows);\r\n\r\nfloat RoomNumX = roomAtlasColumns/6.0;\r\nfloat RoomNumY = roomAtlasRows/3.0;\r\n\r\nfloat Columun = roomAtlasColumns/3.0;\r\nfloat Row = roomAtlasRows/3.0;\r\n\r\nfloat2 _Rooms = float2(RoomNumX, RoomNumY);\r\nfloat2 roomIndexUV = floor(uv);\r\nfloat2 co = roomIndexUV.x + roomIndexUV.y * (roomIndexUV.x + 1);\r\nfloat2 randA = frac(sin(co * float2(12.9898,78.233)) * 43758.5453);\r\n\r\nfloat2 randB = (randA -0.5) * 2;\r\n\r\nfloat2 randC = floor(randA  + 1.0 * (1-nightEmission));\r\nfloat nightBlendingRand = lerp(1, randC , nightEmission);\r\n\r\n// randomize the room\r\nfloat2 n = floor(randA * _Rooms.xy);\r\nroomIndexUV += n;\r\n\r\nfloat2 windowUV = {0,0};\r\n\r\nfloat distPlane = 0.01 / rayDir.z;\r\nfloat3 rayHitPlane = uvw + rayDir * distPlane;\r\nwindowUV += rayHitPlane.xy + float2(2,2);\r\nwindowUV *= float2(tileX, tileY);\r\nwindowUV.x += n.x / RoomNumX;\r\nwindowUV.y += n.y / RoomNumY;\r\nfloat4 windowColor = RoomAtlasTex.Sample(Sampler, windowUV);\r\nfloat4 windowColor2 = RoomAtlasTex.Sample(Sampler, windowUV + float2(1/Columun,0));\r\nwindowColor = lerp(windowColor, windowColor2, nightBlendingRand);\r\nwindowColor.a *= step(distPlane, dist);\r\n\r\ndistPlane = 0.01 / rayDir.z;\r\nrayHitPlane = uvw + rayDir * distPlane;\r\n\r\nfloat2 roomsUV = {0,0};\r\nroomsUV += rayHitNormal.x * (rayHit.zy + float2(2 * step(0.5, rayHit.x), 1));\r\nroomsUV += rayHitNormal.y * (rayHit.xz + float2(1, 2 * step(0.5, rayHit.y)));\r\nroomsUV += rayHitNormal.z * (rayHit.xy + float2(1, 1));\r\nroomsUV *= float2(tileX, tileY);\r\nroomsUV.x += n.x / RoomNumX;\r\nroomsUV.y += n.y / RoomNumY;\r\n\r\nfloat4 roomColor = RoomAtlasTex.Sample(Sampler, roomsUV);\r\nfloat4 roomColor2 = RoomAtlasTex.Sample(Sampler, roomsUV + float2(1/Columun,0));\r\nroomColor = lerp(roomColor, roomColor2, nightBlendingRand);\r\n\r\nfloat randD= frac(sin(dot(roomIndexUV.xy, float2(12.9898,78.233))) * 43758.5453);\r\n//float3 randRGB = Unity_SampleGradient_float(Gradient, randD);\r\n\r\n//roomColor.rgb = color;\r\n//roomColor.rgb *= randRGB;\r\n\r\nroomColor.a = 1.0;\r\n\r\nfloat4 finalColor = lerp(roomColor, windowColor, windowColor.a);\r\n\r\nColor = roomColor;\r\nNight = nightBlendingRand;\r\nEmissive = roomColor.a * (1-windowColor.a);\r\n\r\n"
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
-    "m_ObjectId": "8196032c5e254b5d8c3239133f7dadb6",
-    "m_Id": 878772836,
-    "m_DisplayName": "texture",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_texture",
-    "m_StageCapability": 2,
-    "m_BareResource": false,
-    "m_Texture": {
-        "m_SerializedTexture": "",
-        "m_Guid": ""
-    },
-    "m_DefaultType": 0
 }
 
 {
@@ -28169,18 +27956,25 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "83a27826fa96482f8f876463196c640c",
-    "m_Id": 1426526534,
-    "m_DisplayName": "tile",
-    "m_SlotType": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "8396d722daac4577bf8c52bfc8aa81ee",
+    "m_Id": 0,
+    "m_DisplayName": "YCoef",
+    "m_SlotType": 1,
     "m_Hidden": false,
-    "m_ShaderOutputName": "_tile",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -28229,6 +28023,22 @@
         "e32": 0.0,
         "e33": 1.0
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "83d272e809954f6986daeea8fa17b29e",
+    "m_Id": 127769700,
+    "m_DisplayName": "PixelsPerMeter",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_PixelsPerMeter",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
 }
 
 {
@@ -28290,6 +28100,19 @@
     "m_Property": {
         "m_Id": "67f8ab6e6a6c4abab73b8f957d176d14"
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
+    "m_ObjectId": "84678a8a6dc94e8f92a3e64fffadda4b",
+    "m_Id": 0,
+    "m_DisplayName": "FrontTexture",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_BareResource": false
 }
 
 {
@@ -28424,6 +28247,86 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
+    "m_ObjectId": "850411bd31e94ff4a0ee556aeccfec4b",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "PLATEAU Lod 1 Triplanar Sub",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -996.00048828125,
+            "y": -2798.000244140625,
+            "width": 244.00030517578126,
+            "height": 447.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "5be9bb66f16240ccab2c816f5f7977dd"
+        },
+        {
+            "m_Id": "9250bae6347446e8abd52ac88a77710a"
+        },
+        {
+            "m_Id": "dfadc5216d0d42a49865b6d8e0935827"
+        },
+        {
+            "m_Id": "6784b08274c0441081b8f121246e30a8"
+        },
+        {
+            "m_Id": "6f39f3fc1d4042b882718857cb85f864"
+        },
+        {
+            "m_Id": "cd65f87a68224865bf3978a26b4cc7e9"
+        },
+        {
+            "m_Id": "f7b0f343999c4e9fbaed96ec8fa8c710"
+        },
+        {
+            "m_Id": "e663830dc1f646d8bf51f134488124d5"
+        },
+        {
+            "m_Id": "15dfdec31d534bb0bf9763d8c386ae3a"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedSubGraph": "{\n    \"subGraph\": {\n        \"fileID\": -5475051401550479605,\n        \"guid\": \"dddc4c6b563945640a528c2298f6eb80\",\n        \"type\": 3\n    }\n}",
+    "m_PropertyGuids": [
+        "b533a582-e8cf-4db5-8f6d-b7baa6225076",
+        "df3c24b2-12cc-43d9-b0b9-51949afb0c22",
+        "33fa6efa-2a2f-4f4d-bce8-dde070878341",
+        "8c149f45-cd88-4128-9f63-45b4dfc231bc",
+        "39b918d5-46fa-4877-8288-2621ebc7ef05",
+        "079e4f5d-ec91-4bcc-bdd3-073d15ecc876",
+        "0fe1fc72-09ee-4a75-bb76-243e78518e14",
+        "b08c4047-354e-4cb9-a8fe-42a10399c54b"
+    ],
+    "m_PropertyIds": [
+        878772836,
+        716731476,
+        -571921639,
+        -985074803,
+        1426526534,
+        127769700,
+        1866388063,
+        380768930
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -28648,22 +28551,6 @@
         "z": 0.0,
         "w": 0.0
     },
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "8685dc7316ce4916887514b0a30a74b6",
-    "m_Id": 0,
-    "m_DisplayName": "Tile",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
     "m_LiteralMode": false
 }
 
@@ -28999,24 +28886,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
-    "m_ObjectId": "885692fc03a4454ea1a877beff199894",
-    "m_Id": 878772836,
-    "m_DisplayName": "texture",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_texture",
-    "m_StageCapability": 2,
-    "m_BareResource": false,
-    "m_Texture": {
-        "m_SerializedTexture": "",
-        "m_Guid": ""
-    },
-    "m_DefaultType": 0
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
     "m_ObjectId": "88c93a7171514fdd87bcf9da570e5d1a",
     "m_Group": {
@@ -29202,44 +29071,37 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.AddNode",
-    "m_ObjectId": "89deb85c0ab54a3198ac53487d18cf90",
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "8a4d0731ab8d453482c4bd4284acbdd0",
     "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
     },
-    "m_Name": "Add",
+    "m_Name": "Property",
     "m_DrawState": {
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 434.9999084472656,
-            "y": -2766.000244140625,
-            "width": 208.00015258789063,
-            "height": 302.0
+            "x": -1337.000244140625,
+            "y": -3188.000244140625,
+            "width": 93.9998779296875,
+            "height": 34.0
         }
     },
     "m_Slots": [
         {
-            "m_Id": "e16d4e1fed744a529c22d5dc95e10a51"
-        },
-        {
-            "m_Id": "6d20674749df43c9a6587288631967dc"
-        },
-        {
-            "m_Id": "b0aea3e381924817a5003aa1d6603ca9"
+            "m_Id": "a29e64e006f34585beee9ffa7c93df76"
         }
     ],
-    "synonyms": [
-        "addition",
-        "sum",
-        "plus"
-    ],
+    "synonyms": [],
     "m_Precision": 0,
     "m_PreviewExpanded": true,
     "m_DismissedVersion": 0,
     "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "d77aab930a714b9699447f50d86ac852"
     }
 }
 
@@ -29697,6 +29559,31 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "8b96d9dd2bde458aa64e915f771af0d2",
+    "m_Id": 1,
+    "m_DisplayName": "Out_Vector4",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutVector4",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "8be71ca2be0f485b8edc86b03b270fa5",
     "m_Id": 0,
@@ -29940,7 +29827,7 @@
     "m_ObjectId": "8cffa81326e84675ba7188a9e649c422",
     "m_Title": "Scaling by Distance",
     "m_Position": {
-        "x": -503.0,
+        "x": -503.0001220703125,
         "y": -809.0
     }
 }
@@ -30564,6 +30451,22 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "8f2ce5153e9a45ff996c566775e1f15b",
+    "m_Id": 0,
+    "m_DisplayName": "Metallic",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Metallic",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1Node",
     "m_ObjectId": "8f3cbf81317e4eae9662177580f18142",
     "m_Group": {
@@ -30846,6 +30749,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "90e36ed1fc0b4762b9205ec008f15467",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1204.0003662109375,
+            "y": -3346.000244140625,
+            "width": 141.9998779296875,
+            "height": 34.000244140625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "176867340a1245d7b77788165466ef4b"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "70d3c3d92c2a46f0a90c8ce6d51ade25"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "91b12544312040f491e13d68e2d7ea0f",
     "m_Id": 3,
@@ -30887,6 +30826,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "91ebbc86e49747e59e198ad1f551edf0",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1211.0,
+            "y": -1781.0001220703125,
+            "width": 93.999755859375,
+            "height": 34.0001220703125
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "9b1dbedf13a3459ca2f9c3123673976d"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "d77aab930a714b9699447f50d86ac852"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "92106d45b39344718e0e44ae65fec360",
     "m_Id": 1164418985,
@@ -30915,6 +30890,29 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "9250bae6347446e8abd52ac88a77710a",
+    "m_Id": 716731476,
+    "m_DisplayName": "normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_normal",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 1.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -31464,6 +31462,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "94d54c79807446f89188a747e766bdc0",
+    "m_Id": 716731476,
+    "m_DisplayName": "normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_normal",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "94e52b89b1324c40abaea0124d2fa3df",
     "m_Id": 0,
@@ -31645,6 +31666,22 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "958544a686ee421983538d79ab04c724",
+    "m_Id": 0,
+    "m_DisplayName": "PixelsPerMeter",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "95aa2f7285fd469eb4597e83284da03b",
     "m_Id": 1,
@@ -31779,65 +31816,6 @@
     "m_Property": {
         "m_Id": "e6c35248a8a54a55b45be51bf975fa9e"
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "968514b2b5b54f8ba250cab2e309fa94",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -829.0001831054688,
-            "y": -1784.0001220703125,
-            "width": 94.00006103515625,
-            "height": 33.9998779296875
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "9ac2d0ca3bec4907949125e87f0b6b4b"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "d77aab930a714b9699447f50d86ac852"
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "96b456ed911e4f199ef02f4bba4d1a72",
-    "m_Id": 0,
-    "m_DisplayName": "Min",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -32165,60 +32143,25 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
-    "m_ObjectId": "990ac29263d744c9a3304838734c52e1",
-    "m_Id": 1,
-    "m_DisplayName": "Out_Vector4",
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "99234c7dae454cd3a352c815f95a0be0",
+    "m_Id": 0,
+    "m_DisplayName": "XCoef",
     "m_SlotType": 1,
     "m_Hidden": false,
-    "m_ShaderOutputName": "OutVector4",
-    "m_StageCapability": 2,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
     "m_Value": {
         "x": 0.0,
         "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
+        "z": 0.0
     },
     "m_DefaultValue": {
         "x": 0.0,
         "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
+        "z": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector3ShaderProperty",
-    "m_ObjectId": "9934abfc36164c329a0480b30ef0c8eb",
-    "m_Guid": {
-        "m_GuidSerialized": "1268dd9f-bcbc-47d3-b068-8787dd8dabb5"
-    },
-    "promotedFromAssetID": "",
-    "promotedFromCategoryName": "",
-    "promotedOrdering": -1,
-    "m_Name": "XCoef",
-    "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "XCoef",
-    "m_DefaultReferenceName": "_XCoef",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
-    "m_DismissedVersion": 0,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_PerRendererData": false,
-    "m_customAttributes": [],
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
 }
 
 {
@@ -32300,6 +32243,22 @@
         "y": 1.0
     },
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "99c8cf98b022491cbad5fd3cd8a9cf5b",
+    "m_Id": 0,
+    "m_DisplayName": "Tile",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
 }
 
 {
@@ -32415,6 +32374,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "9a3533bb796a46d0b01668623ee8094e",
+    "m_Id": -571921639,
+    "m_DisplayName": "origin",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_origin",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "9a544ca7de97422d8ab2a620d6e7f83b",
     "m_Id": 1,
@@ -32520,7 +32502,7 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "9ac2d0ca3bec4907949125e87f0b6b4b",
+    "m_ObjectId": "9b1dbedf13a3459ca2f9c3123673976d",
     "m_Id": 0,
     "m_DisplayName": "Tile",
     "m_SlotType": 1,
@@ -32707,22 +32689,6 @@
         "z": 0.0,
         "w": 0.0
     },
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "9cc3ab9a0f8f4be09bc08b59186c9f4e",
-    "m_Id": 127769700,
-    "m_DisplayName": "PixelsPerMeter",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_PixelsPerMeter",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
     "m_LiteralMode": false
 }
 
@@ -33027,86 +32993,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
-    "m_ObjectId": "9f5d83a0eee04ccd89093c86ce970031",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "PLATEAU Lod 1 Triplanar Sub",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -588.0001831054688,
-            "y": -1489.0001220703125,
-            "width": 244.0001220703125,
-            "height": 446.9998779296875
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "e444a93649a543f0bf22a48b9b43c258"
-        },
-        {
-            "m_Id": "17033b383fb249f4889f2b9f729b2b59"
-        },
-        {
-            "m_Id": "53394faf8fac4da48aea6c3788ffd732"
-        },
-        {
-            "m_Id": "7b96b8ef186244fd9836405ca232e4b6"
-        },
-        {
-            "m_Id": "63e3fb92aa61477790a1cf1521ed8106"
-        },
-        {
-            "m_Id": "db5ecd60ccef4a6d90b74fbae23d7f5e"
-        },
-        {
-            "m_Id": "fd26ffba414b40479b20109ee23edf6e"
-        },
-        {
-            "m_Id": "ed6534412d7d4d918812af342ecfbfc8"
-        },
-        {
-            "m_Id": "4c5f0ad44e464738b6d4104810118365"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedSubGraph": "{\n    \"subGraph\": {\n        \"fileID\": -5475051401550479605,\n        \"guid\": \"dddc4c6b563945640a528c2298f6eb80\",\n        \"type\": 3\n    }\n}",
-    "m_PropertyGuids": [
-        "b533a582-e8cf-4db5-8f6d-b7baa6225076",
-        "df3c24b2-12cc-43d9-b0b9-51949afb0c22",
-        "33fa6efa-2a2f-4f4d-bce8-dde070878341",
-        "8c149f45-cd88-4128-9f63-45b4dfc231bc",
-        "39b918d5-46fa-4877-8288-2621ebc7ef05",
-        "079e4f5d-ec91-4bcc-bdd3-073d15ecc876",
-        "0fe1fc72-09ee-4a75-bb76-243e78518e14",
-        "b08c4047-354e-4cb9-a8fe-42a10399c54b"
-    ],
-    "m_PropertyIds": [
-        878772836,
-        716731476,
-        -571921639,
-        -985074803,
-        1426526534,
-        127769700,
-        1866388063,
-        380768930
-    ],
-    "m_Dropdowns": [],
-    "m_DropdownSelectedEntries": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "9f658c74cc7e41119afb12a95dc966cd",
     "m_Id": 0,
@@ -33306,39 +33192,6 @@
 }
 
 {
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector3ShaderProperty",
-    "m_ObjectId": "a131527a1e2f4ee08b1be704ee20ee5b",
-    "m_Guid": {
-        "m_GuidSerialized": "217ea322-5b09-46f6-a9fe-1aa116b5705d"
-    },
-    "promotedFromAssetID": "",
-    "promotedFromCategoryName": "",
-    "promotedOrdering": -1,
-    "m_Name": "Max",
-    "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "Max",
-    "m_DefaultReferenceName": "_Max",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
-    "m_DismissedVersion": 0,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_PerRendererData": false,
-    "m_customAttributes": [],
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
-}
-
-{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "a13c4a71b12e4fa2a6e667b24b3aeffd",
@@ -33528,6 +33381,22 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "a29e64e006f34585beee9ffa7c93df76",
+    "m_Id": 0,
+    "m_DisplayName": "Tile",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
     "m_ObjectId": "a2a2167fcf4f4e85a86d38c228be4598",
     "m_Id": 0,
@@ -33591,6 +33460,39 @@
     "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector3ShaderProperty",
+    "m_ObjectId": "a2a8a714e6d843c4ae8d0888b912da24",
+    "m_Guid": {
+        "m_GuidSerialized": "3544ce94-d299-4b8b-be85-e0c30a10ac1e"
+    },
+    "promotedFromAssetID": "",
+    "promotedFromCategoryName": "",
+    "promotedOrdering": -1,
+    "m_Name": "XCoef",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "XCoef",
+    "m_DefaultReferenceName": "_XCoef",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_PerRendererData": false,
+    "m_customAttributes": [],
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     }
 }
 
@@ -34013,31 +33915,6 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "a4b7e03a94d94b07b5eaac5e137132bc",
-    "m_Id": 2,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "a4bc990708c94b71925f72410b213d35",
     "m_Id": 0,
     "m_DisplayName": "In",
@@ -34083,6 +33960,49 @@
         "w": 0.0
     },
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AddNode",
+    "m_ObjectId": "a4ed2a3823c54e3aa189ab63f21c9e92",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Add",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -608.9999389648438,
+            "y": -2536.000244140625,
+            "width": 207.99981689453126,
+            "height": 302.000244140625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c3e57b33623e4085b25b8d02bae4a743"
+        },
+        {
+            "m_Id": "f07391b25e554854b32928cc6d38f6b8"
+        },
+        {
+            "m_Id": "5f9200347eba468980183968b8c2706d"
+        }
+    ],
+    "synonyms": [
+        "addition",
+        "sum",
+        "plus"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -34222,6 +34142,42 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "a679864b96aa47b4b1c09860312e9b85",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1293.000244140625,
+            "y": -2399.000244140625,
+            "width": 150.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "246d1274bf114970bc527584f994f2a9"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "26f5377eeaca4c1198f8eaed1ebdf4cb"
+    }
 }
 
 {
@@ -34378,8 +34334,8 @@
     "m_ObjectId": "a87e5ff5bc514db192f9e8041313653b",
     "m_Title": "Emission Fade By Distance",
     "m_Position": {
-        "x": -5247.0009765625,
-        "y": 3301.999755859375
+        "x": -5247.0,
+        "y": 3302.0
     }
 }
 
@@ -34861,6 +34817,22 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "aa6089b0c5164fc1b52213bfb6f0093a",
+    "m_Id": 0,
+    "m_DisplayName": "PixelsPerMeter",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "aa6405504c2042d99f5a3d39d974e29b",
     "m_Id": 0,
     "m_DisplayName": "_IsNight",
@@ -34942,42 +34914,6 @@
     "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "aa77d1b9745d4a46874483cc2d487827",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -805.000244140625,
-            "y": -3267.000244140625,
-            "width": 96.00018310546875,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "6850c00a45ee4533bd029fbed0066b48"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "2f0fc2f20ea54732a65ea368672ea06c"
     }
 }
 
@@ -35076,6 +35012,22 @@
         "z": 0.0,
         "w": 0.0
     },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "ab1280fc56244582a91f3644045ebfde",
+    "m_Id": 0,
+    "m_DisplayName": "PixelsPerMeter",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
     "m_LiteralMode": false
 }
 
@@ -35295,6 +35247,42 @@
         "y": 1.0
     },
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
+    "m_ObjectId": "ac503bef496344ad8b9dfb5bbb213f9b",
+    "m_Guid": {
+        "m_GuidSerialized": "645487b6-35f9-4683-9996-7eabfe3151c0"
+    },
+    "promotedFromAssetID": "",
+    "promotedFromCategoryName": "",
+    "promotedOrdering": -1,
+    "m_Name": "LeftTexture",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "LeftTexture",
+    "m_DefaultReferenceName": "_LeftTexture",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_PerRendererData": false,
+    "m_customAttributes": [],
+    "m_Value": {
+        "m_SerializedTexture": "",
+        "m_Guid": ""
+    },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
+    "useTexelSize": true,
+    "m_Modifiable": true,
+    "m_DefaultType": 0
 }
 
 {
@@ -35534,6 +35522,22 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "ad94e63f798b4736a69b1d64ab11cf2b",
+    "m_Id": 127769700,
+    "m_DisplayName": "PixelsPerMeter",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_PixelsPerMeter",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "adc1234b0cb14b47a22cd39038fadd39",
     "m_Id": 2,
     "m_DisplayName": "Mask",
@@ -35581,6 +35585,22 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "ade3d41adc1d4607bf5362f414988981",
+    "m_Id": 1426526534,
+    "m_DisplayName": "tile",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_tile",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
 }
 
 {
@@ -35696,18 +35716,38 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "af1977dce9194432b44cda1aed4394e9",
-    "m_Id": 1426526534,
-    "m_DisplayName": "tile",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_tile",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "af33720f092d4a1680a6c8587627b511",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1118.0001220703125,
+            "y": -1250.9998779296875,
+            "width": 93.9998779296875,
+            "height": 33.9996337890625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "99c8cf98b022491cbad5fd3cd8a9cf5b"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "d77aab930a714b9699447f50d86ac852"
+    }
 }
 
 {
@@ -35894,31 +35934,6 @@
 }
 
 {
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "b0aea3e381924817a5003aa1d6603ca9",
-    "m_Id": 2,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_LiteralMode": false
-}
-
-{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector2ShaderProperty",
     "m_ObjectId": "b0af910d39114dcaa429bbf73873794c",
@@ -35949,22 +35964,6 @@
         "z": 0.0,
         "w": 0.0
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "b0fb5366129041e18c10e758c61b0ff1",
-    "m_Id": 0,
-    "m_DisplayName": "Tile",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
 }
 
 {
@@ -36276,19 +36275,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
-    "m_ObjectId": "b29ed0ba1cf34f4dbf6864a0c311006b",
-    "m_Id": 0,
-    "m_DisplayName": "LeftTexture",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_BareResource": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "b2aec8aa482d4c51b433ee33ae59e1bd",
     "m_Id": 0,
@@ -36430,22 +36416,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "b32a40d1840e4c63a31e2952a0d46271",
-    "m_Id": 0,
-    "m_DisplayName": "Tile",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
     "m_ObjectId": "b33b71dffb9f472d990a16c3457df3db",
     "m_Id": 0,
@@ -36521,6 +36491,31 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "b37bed9799374f818ad9be41387ff069",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
     "m_ObjectId": "b47160b48cb246c09c1bdeb0ff077a64",
     "m_Id": 2,
@@ -36555,42 +36550,6 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "b4a2ff8b650d4363bbe9cdb3e0850f5b",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -810.0001831054688,
-            "y": -2124.0,
-            "width": 154.00006103515626,
-            "height": 33.999755859375
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "4c7912f07d6e48ce9968aac53413ad12"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "1e81c5d7f04a4ba9bfccbbb370fec9a7"
-    }
 }
 
 {
@@ -36804,6 +36763,29 @@
         "m_NumColorKeys": 2,
         "m_NumAlphaKeys": 2
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "b4e18a6f8c534f89ae2a3ca59d6e6059",
+    "m_Id": 0,
+    "m_DisplayName": "Min",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -37313,29 +37295,6 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "b62334f7eef04807a2a19824244e037d",
-    "m_Id": 0,
-    "m_DisplayName": "Min",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -37854,31 +37813,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "b931bae2ee7d47e39eb653cdca650f0d",
-    "m_Id": 2,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.LerpNode",
     "m_ObjectId": "b964df7e1dd04a8e8f031d2747c82335",
     "m_Group": {
@@ -38143,6 +38077,75 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "ba7c82cf79634a40802f68307af1163b",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1187.000244140625,
+            "y": -3264.000244140625,
+            "width": 96.0001220703125,
+            "height": 34.000244140625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "59eba968bf064d2ea79d4b14ba8eb81d"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "bac640b190f64590a1e634b743694ff4"
+    }
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector3ShaderProperty",
+    "m_ObjectId": "bac640b190f64590a1e634b743694ff4",
+    "m_Guid": {
+        "m_GuidSerialized": "b5d87828-467f-4507-9173-be0a7e0a4b67"
+    },
+    "promotedFromAssetID": "",
+    "promotedFromCategoryName": "",
+    "promotedOrdering": -1,
+    "m_Name": "Min",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Min",
+    "m_DefaultReferenceName": "_Min",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_PerRendererData": false,
+    "m_customAttributes": [],
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "bae2415d1040484783c0df096cdf0928",
     "m_Id": 3,
@@ -38310,6 +38313,29 @@
     "m_EnumValues": [
         0
     ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "bb7dd2de904c4d4396b5f967797d864f",
+    "m_Id": -985074803,
+    "m_DisplayName": "coef",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_coef",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -38563,6 +38589,22 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "bd2335dad9ee4dabb5b762f8dbed1052",
+    "m_Id": 1426526534,
+    "m_DisplayName": "tile",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_tile",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "bd563980a04142eda36e579cb0d2f4eb",
     "m_Id": 6,
     "m_DisplayName": "Width",
@@ -38612,31 +38654,6 @@
     },
     "m_Width": 208.0,
     "m_Height": 208.0
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "bdf534d3842a4fd59a566be7622133e8",
-    "m_Id": 0,
-    "m_DisplayName": "A",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "A",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_LiteralMode": false
 }
 
 {
@@ -38770,6 +38787,42 @@
     "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "be4a444895604fa496a169de554c166e",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1141.0,
+            "y": -2235.0,
+            "width": 108.9996337890625,
+            "height": 33.99951171875
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "4d07ef0264bf45099011c3933127c9c7"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "a2a8a714e6d843c4ae8d0888b912da24"
     }
 }
 
@@ -39245,30 +39298,51 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.Rendering.HighDefinition.ShaderGraph.HDLitData",
-    "m_ObjectId": "c0f7015544a547369184fd5096021443",
-    "m_RayTracing": false,
-    "m_MaterialType": 0,
-    "m_RefractionModel": 0,
-    "m_SSSTransmission": true,
-    "m_EnergyConservingSpecular": true,
-    "m_ClearCoat": false
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "c0f4eea11130445ba24bf938aa8fa51e",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1447.0001220703125,
+            "y": -1657.000244140625,
+            "width": 98.9996337890625,
+            "height": 34.0001220703125
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "d358f0d895fb42298c7ee46b7eb34efb"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "dc022c39e6bb4ac8afc5ea58baa21213"
+    }
 }
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "c112b199308242f79731994bdf462ecb",
-    "m_Id": 127769700,
-    "m_DisplayName": "PixelsPerMeter",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_PixelsPerMeter",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
+    "m_Type": "UnityEditor.Rendering.HighDefinition.ShaderGraph.HDLitData",
+    "m_ObjectId": "c0f7015544a547369184fd5096021443",
+    "m_RayTracing": false,
+    "m_MaterialType": 0,
+    "m_MaterialTypeMask": 2,
+    "m_RefractionModel": 0,
+    "m_SSSTransmission": true,
+    "m_EnergyConservingSpecular": true,
+    "m_ClearCoat": false
 }
 
 {
@@ -39642,31 +39716,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "c2cd7e15495646dc9a896d91d5ec4163",
-    "m_Id": 0,
-    "m_DisplayName": "A",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "A",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1Node",
     "m_ObjectId": "c2deecd37fd64cc2b42453f6c28766df",
     "m_Group": {
@@ -39784,6 +39833,19 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
+    "m_ObjectId": "c3641ddce6ac49a39c363ff68feb2c1f",
+    "m_Id": 0,
+    "m_DisplayName": "LeftTexture",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.RedirectNodeData",
     "m_ObjectId": "c39f506886c846a58f9e52ddc0749702",
     "m_Group": {
@@ -39833,6 +39895,31 @@
     "m_Labels": [
         "X"
     ],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "c3e57b33623e4085b25b8d02bae4a743",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
     "m_LiteralMode": false
 }
 
@@ -40175,6 +40262,24 @@
         "y": 1.0
     },
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "c6b4ae40290f41de9b54646ef91b4d7a",
+    "m_Id": 878772836,
+    "m_DisplayName": "texture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_texture",
+    "m_StageCapability": 2,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
 }
 
 {
@@ -40587,86 +40692,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
-    "m_ObjectId": "ca31e9638dae41d0b3e84ef4321cf93d",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "PLATEAU Lod 1 Triplanar Sub",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -614.0001831054688,
-            "y": -2392.00048828125,
-            "width": 243.99993896484376,
-            "height": 447.000244140625
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "885692fc03a4454ea1a877beff199894"
-        },
-        {
-            "m_Id": "49fa8b7595a84f67ad055d190540e914"
-        },
-        {
-            "m_Id": "027d47fb39154492bf0888a12c4816d0"
-        },
-        {
-            "m_Id": "8029ef51ded24f589c07d9b5f538927b"
-        },
-        {
-            "m_Id": "83a27826fa96482f8f876463196c640c"
-        },
-        {
-            "m_Id": "30bbc20e887f46f5b4c4f9f7e01699a2"
-        },
-        {
-            "m_Id": "d957b7e2d95141fea08d577c530783fa"
-        },
-        {
-            "m_Id": "cc4c43f6330041e1820822d62c8587f0"
-        },
-        {
-            "m_Id": "10caa5fa3bb4430da9b61d63480bb54f"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedSubGraph": "{\n    \"subGraph\": {\n        \"fileID\": -5475051401550479605,\n        \"guid\": \"dddc4c6b563945640a528c2298f6eb80\",\n        \"type\": 3\n    }\n}",
-    "m_PropertyGuids": [
-        "b533a582-e8cf-4db5-8f6d-b7baa6225076",
-        "df3c24b2-12cc-43d9-b0b9-51949afb0c22",
-        "33fa6efa-2a2f-4f4d-bce8-dde070878341",
-        "8c149f45-cd88-4128-9f63-45b4dfc231bc",
-        "39b918d5-46fa-4877-8288-2621ebc7ef05",
-        "079e4f5d-ec91-4bcc-bdd3-073d15ecc876",
-        "0fe1fc72-09ee-4a75-bb76-243e78518e14",
-        "b08c4047-354e-4cb9-a8fe-42a10399c54b"
-    ],
-    "m_PropertyIds": [
-        878772836,
-        716731476,
-        -571921639,
-        -985074803,
-        1426526534,
-        127769700,
-        1866388063,
-        380768930
-    ],
-    "m_Dropdowns": [],
-    "m_DropdownSelectedEntries": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BooleanMaterialSlot",
     "m_ObjectId": "ca98dc6cf4b34953bcf3874520f1b28f",
     "m_Id": 0,
@@ -40932,25 +40957,27 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "cc4c43f6330041e1820822d62c8587f0",
-    "m_Id": 380768930,
-    "m_DisplayName": "b",
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "cc3d042ccf964875b4937fc9fcdb6fab",
+    "m_Id": 1,
+    "m_DisplayName": "B",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "_b",
-    "m_StageCapability": 2,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
     "m_Value": {
         "x": 0.0,
         "y": 0.0,
-        "z": 0.0
+        "z": 0.0,
+        "w": 0.0
     },
     "m_DefaultValue": {
         "x": 0.0,
         "y": 0.0,
-        "z": 0.0
+        "z": 0.0,
+        "w": 0.0
     },
-    "m_Labels": []
+    "m_LiteralMode": false
 }
 
 {
@@ -41065,6 +41092,45 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "cd65f87a68224865bf3978a26b4cc7e9",
+    "m_Id": 127769700,
+    "m_DisplayName": "PixelsPerMeter",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_PixelsPerMeter",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "cd6d904811744a55948af4419106a0e4",
+    "m_Id": 716731476,
+    "m_DisplayName": "normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_normal",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": -1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -41470,6 +41536,19 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
+    "m_ObjectId": "cfd41c4c23bd49eaa4919697cc6c52b6",
+    "m_Id": 0,
+    "m_DisplayName": "BackTexture",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.RedirectNodeData",
     "m_ObjectId": "cfe68c7b03d848c184f64600482ced90",
     "m_Group": {
@@ -41583,31 +41662,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
-    "m_ObjectId": "d0bd5d64b4f54d98b2cc3794ab4aedbf",
-    "m_Id": 1,
-    "m_DisplayName": "Out_Vector4",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "OutVector4",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.RemapNode",
     "m_ObjectId": "d0d439d297d44dd288f18ae22e2c501d",
     "m_Group": {
@@ -41662,6 +41716,29 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "d10b63ac71a645cbbd03e93ecef0b23e",
+    "m_Id": 380768930,
+    "m_DisplayName": "b",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_b",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 1.0,
+        "y": 0.0,
+        "z": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -41839,6 +41916,42 @@
         "w": 0.0
     },
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "d216079f5fc043aca2c3d4f14c9d623e",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1134.000244140625,
+            "y": -1815.000244140625,
+            "width": 109.0001220703125,
+            "height": 34.0001220703125
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "4d69549270bc45c7b1972d78c86456c8"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "631b2e44385843b1b5e2e29fb91a366f"
+    }
 }
 
 {
@@ -42177,6 +42290,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "d358f0d895fb42298c7ee46b7eb34efb",
+    "m_Id": 0,
+    "m_DisplayName": "Max",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.SaturateNode",
     "m_ObjectId": "d3acad3c7ea641f38a50648fed0fa9a4",
     "m_Group": {
@@ -42287,42 +42423,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
-    "m_ObjectId": "d40b57b8ad414fcfa8dc645697ce0930",
-    "m_Guid": {
-        "m_GuidSerialized": "82beea5e-b631-4c7a-b8a4-835f6b80639a"
-    },
-    "promotedFromAssetID": "",
-    "promotedFromCategoryName": "",
-    "promotedOrdering": -1,
-    "m_Name": "LeftTexture",
-    "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "LeftTexture",
-    "m_DefaultReferenceName": "_LeftTexture",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
-    "m_DismissedVersion": 0,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_PerRendererData": false,
-    "m_customAttributes": [],
-    "m_Value": {
-        "m_SerializedTexture": "",
-        "m_Guid": ""
-    },
-    "isMainTexture": false,
-    "useTilingAndOffset": false,
-    "useTexelSize": true,
-    "m_Modifiable": true,
-    "m_DefaultType": 0
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.RedirectNodeData",
     "m_ObjectId": "d4360e08258546d490de72e76d70f4f2",
     "m_Group": {
@@ -42354,42 +42454,6 @@
     "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "d467bebbe0404637ac83059b48b88639",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -882.0001831054688,
-            "y": -3118.000244140625,
-            "width": 154.00006103515626,
-            "height": 33.999755859375
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "42a4a326ef6044bd8edfe0c6a1242aa0"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "1e81c5d7f04a4ba9bfccbbb370fec9a7"
     }
 }
 
@@ -42666,29 +42730,6 @@
     "m_DefaultValue": {
         "x": 0.0,
         "y": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "d62433c722674d1482f19411eee798a9",
-    "m_Id": 380768930,
-    "m_DisplayName": "b",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_b",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 1.0,
-        "y": 0.0,
-        "z": 1.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
     },
     "m_Labels": []
 }
@@ -43005,6 +43046,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "d7a1e66f03f14775ac9503a4fb83a600",
+    "m_Id": 1866388063,
+    "m_DisplayName": "a",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_a",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.LerpNode",
     "m_ObjectId": "d7a407a449924b47a8efd65a13fc42da",
     "m_Group": {
@@ -43132,6 +43196,42 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "d887090746fe4c06a32db60fcd0c2736",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1134.000244140625,
+            "y": -1375.000244140625,
+            "width": 96.0,
+            "height": 34.0001220703125
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "29ef518d054947948207c3dad6aa5cb5"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "bac640b190f64590a1e634b743694ff4"
+    }
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector2ShaderProperty",
     "m_ObjectId": "d8b2a205321244db8a1edabe93bf8b42",
@@ -43191,25 +43291,107 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "d957b7e2d95141fea08d577c530783fa",
-    "m_Id": 1866388063,
-    "m_DisplayName": "a",
-    "m_SlotType": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
+    "m_ObjectId": "d9011f8c25df48f3b900828b632aff09",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "PLATEAU Lod 1 Triplanar Sub",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -996.00048828125,
+            "y": -2389.0,
+            "width": 244.00030517578126,
+            "height": 446.9996337890625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "fd2bf01c546249bb9652bd7f27f57b9e"
+        },
+        {
+            "m_Id": "5fe96ec219374fceb7e13e722eb478f4"
+        },
+        {
+            "m_Id": "e364b54914b64168b4b9f8802e92d151"
+        },
+        {
+            "m_Id": "484ca62c63934f6583a2d74c704463d7"
+        },
+        {
+            "m_Id": "ade3d41adc1d4607bf5362f414988981"
+        },
+        {
+            "m_Id": "16d279ca0fb748969b1f285cfc3e892a"
+        },
+        {
+            "m_Id": "53cc199980ca48789ecb79f66a166f7a"
+        },
+        {
+            "m_Id": "7e2cc32b239147529dc5c3cc6e779337"
+        },
+        {
+            "m_Id": "64cdd4e868f54ea082a21ec99b37e224"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedSubGraph": "{\n    \"subGraph\": {\n        \"fileID\": -5475051401550479605,\n        \"guid\": \"dddc4c6b563945640a528c2298f6eb80\",\n        \"type\": 3\n    }\n}",
+    "m_PropertyGuids": [
+        "b533a582-e8cf-4db5-8f6d-b7baa6225076",
+        "df3c24b2-12cc-43d9-b0b9-51949afb0c22",
+        "33fa6efa-2a2f-4f4d-bce8-dde070878341",
+        "8c149f45-cd88-4128-9f63-45b4dfc231bc",
+        "39b918d5-46fa-4877-8288-2621ebc7ef05",
+        "079e4f5d-ec91-4bcc-bdd3-073d15ecc876",
+        "0fe1fc72-09ee-4a75-bb76-243e78518e14",
+        "b08c4047-354e-4cb9-a8fe-42a10399c54b"
+    ],
+    "m_PropertyIds": [
+        878772836,
+        716731476,
+        -571921639,
+        -985074803,
+        1426526534,
+        127769700,
+        1866388063,
+        380768930
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "d9755214b58f4cb2b751a4a69c86b7b1",
+    "m_Id": 1,
+    "m_DisplayName": "",
+    "m_SlotType": 1,
     "m_Hidden": false,
-    "m_ShaderOutputName": "_a",
-    "m_StageCapability": 2,
+    "m_ShaderOutputName": "",
+    "m_StageCapability": 3,
     "m_Value": {
-        "x": 1.0,
-        "y": 1.0,
-        "z": 1.0
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     },
     "m_DefaultValue": {
         "x": 0.0,
         "y": 0.0,
-        "z": 0.0
+        "z": 0.0,
+        "w": 0.0
     },
-    "m_Labels": []
+    "m_LiteralMode": false
 }
 
 {
@@ -43268,42 +43450,6 @@
     "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "d9f4c6bb247b42f381c614a556e8620f",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -759.0001220703125,
-            "y": -2238.000244140625,
-            "width": 108.99993896484375,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "6a401ebdc3bd4578a8b071630640e860"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "9934abfc36164c329a0480b30ef0c8eb"
     }
 }
 
@@ -43397,6 +43543,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "dab594fecaa24bbaae91506572f095f1",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1377.0001220703125,
+            "y": -2612.000244140625,
+            "width": 93.999755859375,
+            "height": 34.000244140625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "1890d789471f486cab28f03142e266ac"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "d77aab930a714b9699447f50d86ac852"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "dad54c66f31842319185d82007c49e16",
     "m_Id": 4,
@@ -43434,22 +43616,6 @@
         "w": 0.0
     },
     "m_LiteralMode": true
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "db5ecd60ccef4a6d90b74fbae23d7f5e",
-    "m_Id": 127769700,
-    "m_DisplayName": "PixelsPerMeter",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_PixelsPerMeter",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
 }
 
 {
@@ -43510,6 +43676,39 @@
     "m_DefaultRefNameVersion": 1,
     "m_RefNameGeneratedByDisplayName": "Roof Edge Offset",
     "m_DefaultReferenceName": "_Roof_Edge_Offset",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_PerRendererData": false,
+    "m_customAttributes": [],
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector3ShaderProperty",
+    "m_ObjectId": "dc022c39e6bb4ac8afc5ea58baa21213",
+    "m_Guid": {
+        "m_GuidSerialized": "30ce825d-f48e-4502-8d06-5cf1cab5d750"
+    },
+    "promotedFromAssetID": "",
+    "promotedFromCategoryName": "",
+    "promotedOrdering": -1,
+    "m_Name": "Max",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Max",
+    "m_DefaultReferenceName": "_Max",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
     "m_UseCustomSlotLabel": false,
@@ -43790,29 +43989,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "dce2a14f6c974633aaa9c43b4f2f3f04",
-    "m_Id": 0,
-    "m_DisplayName": "ZCoef",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "dcfbd1154888490a975a00ac7e92eab1",
     "m_Id": 1,
@@ -44017,31 +44193,6 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "de10f3ce888b4960a74753844658bce7",
-    "m_Id": 1,
-    "m_DisplayName": "B",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "B",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "de8674b1b31740388062374063c7d3a7",
     "m_Id": 3,
     "m_DisplayName": "Out",
@@ -44102,6 +44253,31 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "dec9ac56f8634a8bac9cde7315f0fa89",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
     "m_LiteralMode": false
 }
 
@@ -44237,6 +44413,45 @@
     "m_Property": {
         "m_Id": "4ffa8e8baa2c40ec903ce382ce020efc"
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "dfa4cfeffdde4998885769e793f2ec32",
+    "m_Id": 1426526534,
+    "m_DisplayName": "tile",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_tile",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "dfadc5216d0d42a49865b6d8e0935827",
+    "m_Id": -571921639,
+    "m_DisplayName": "origin",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_origin",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -44652,67 +44867,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "e1341d1c1d554cc482019cd251bba3af",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -752.0000610351563,
-            "y": -1378.0001220703125,
-            "width": 95.99993896484375,
-            "height": 33.9998779296875
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "f3e9f5c1cbef4e0495b1d664cd0203e2"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "2f0fc2f20ea54732a65ea368672ea06c"
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "e16d4e1fed744a529c22d5dc95e10a51",
-    "m_Id": 0,
-    "m_DisplayName": "A",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "A",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "e1b6db43e3e649cabef630484e0ef3c5",
     "m_Id": 0,
@@ -44832,36 +44986,53 @@
 }
 
 {
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector3ShaderProperty",
-    "m_ObjectId": "e26a80b03d614a13999c3fa38b99a9b2",
-    "m_Guid": {
-        "m_GuidSerialized": "7e34d743-98ff-49cd-b7c2-7f1d4dd27ea3"
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "e249aa5adde74ff7877cbcca0a3abdcf",
+    "m_Group": {
+        "m_Id": ""
     },
-    "promotedFromAssetID": "",
-    "promotedFromCategoryName": "",
-    "promotedOrdering": -1,
-    "m_Name": "YCoef",
-    "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "YCoef",
-    "m_DefaultReferenceName": "_YCoef",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
-    "m_DismissedVersion": 0,
+    "m_Name": "SurfaceDescription.Metallic",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "8f2ce5153e9a45ff996c566775e1f15b"
+        }
+    ],
+    "synonyms": [],
     "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Metallic"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "e280e8ba3f4146aca7c353782ea8c79e",
+    "m_Id": 0,
+    "m_DisplayName": "Alpha Clip Threshold",
+    "m_SlotType": 0,
     "m_Hidden": false,
-    "m_PerRendererData": false,
-    "m_customAttributes": [],
-    "m_Value": {
-        "x": 1.0,
-        "y": 1.0,
-        "z": 1.0,
-        "w": 0.0
-    }
+    "m_ShaderOutputName": "AlphaClipThreshold",
+    "m_StageCapability": 2,
+    "m_Value": 0.5,
+    "m_DefaultValue": 0.5,
+    "m_Labels": [],
+    "m_LiteralMode": false
 }
 
 {
@@ -44940,6 +45111,29 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "e364b54914b64168b4b9f8802e92d151",
+    "m_Id": -571921639,
+    "m_DisplayName": "origin",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_origin",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -45041,24 +45235,6 @@
         "w": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
-    "m_ObjectId": "e444a93649a543f0bf22a48b9b43c258",
-    "m_Id": 878772836,
-    "m_DisplayName": "texture",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_texture",
-    "m_StageCapability": 2,
-    "m_BareResource": false,
-    "m_Texture": {
-        "m_SerializedTexture": "",
-        "m_Guid": ""
-    },
-    "m_DefaultType": 0
 }
 
 {
@@ -45198,6 +45374,42 @@
         "w": 0.0
     },
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "e4e0c95635014540b57547629ebdc4d5",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1165.000244140625,
+            "y": -1474.0,
+            "width": 148.00018310546876,
+            "height": 34.0001220703125
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "cfd41c4c23bd49eaa4919697cc6c52b6"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "059fefe3c6cc4f79a88d71e70088f647"
+    }
 }
 
 {
@@ -45478,6 +45690,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "e560845eae7b46d7a62e7a8872791fff",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1337.000244140625,
+            "y": -2664.000244140625,
+            "width": 109.0001220703125,
+            "height": 34.000244140625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "99234c7dae454cd3a352c815f95a0be0"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "a2a8a714e6d843c4ae8d0888b912da24"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
     "m_ObjectId": "e584b09b12764ad1abe99273f3c2eb46",
     "m_Group": {
@@ -45578,6 +45826,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "e62d05b875f147149823d81bb8cd049e",
+    "m_Id": -571921639,
+    "m_DisplayName": "origin",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_origin",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
     "m_ObjectId": "e663187ac56c494a953bc44695edebe7",
     "m_Group": {
@@ -45621,38 +45892,25 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
-    "m_ObjectId": "e665594047ea42ec9cce2355de477c43",
-    "m_Guid": {
-        "m_GuidSerialized": "708d9266-fc78-419c-817b-f3b53a2d0ccd"
-    },
-    "promotedFromAssetID": "",
-    "promotedFromCategoryName": "",
-    "promotedOrdering": -1,
-    "m_Name": "TopTexture",
-    "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "TopTexture",
-    "m_DefaultReferenceName": "_TopTexture",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
-    "m_DismissedVersion": 0,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "e663830dc1f646d8bf51f134488124d5",
+    "m_Id": 380768930,
+    "m_DisplayName": "b",
+    "m_SlotType": 0,
     "m_Hidden": false,
-    "m_PerRendererData": false,
-    "m_customAttributes": [],
+    "m_ShaderOutputName": "_b",
+    "m_StageCapability": 2,
     "m_Value": {
-        "m_SerializedTexture": "",
-        "m_Guid": ""
+        "x": 1.0,
+        "y": 0.0,
+        "z": 1.0
     },
-    "isMainTexture": false,
-    "useTilingAndOffset": false,
-    "useTexelSize": true,
-    "m_Modifiable": true,
-    "m_DefaultType": 0
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -45689,6 +45947,30 @@
         "w": 0.0
     },
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "e6ac44addd7f4ba99830af48908783d4",
+    "m_Id": 0,
+    "m_DisplayName": "Normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Normal",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
 }
 
 {
@@ -45918,12 +46200,28 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "e72991c17f83490596744baa9c0c9434",
+    "m_Id": 0,
+    "m_DisplayName": "PixelsPerMeter",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.GroupData",
     "m_ObjectId": "e743043400924c0797480b7a8a766dd4",
     "m_Title": "Rain",
     "m_Position": {
-        "x": 705.0001220703125,
-        "y": -115.00009155273438
+        "x": 705.0,
+        "y": -115.0
     }
 }
 
@@ -45972,6 +46270,22 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "e770e729f78546728203d93dc2fdfcbd",
+    "m_Id": 0,
+    "m_DisplayName": "PixelsPerMeter",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
 }
 
 {
@@ -46044,42 +46358,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "e82d6489234b439abbbbe6c17117867e",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -805.000244140625,
-            "y": -3225.00048828125,
-            "width": 109.00006103515625,
-            "height": 34.000244140625
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "f3654a1348834940ac00f83248c7aa54"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "e26a80b03d614a13999c3fa38b99a9b2"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "e82d6b9f2b8b4b2393b5f9d386e56079",
     "m_Id": 1,
@@ -46101,6 +46379,40 @@
         "w": 0.0
     },
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "e834d47a19be44009843db4a60450ef2",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.AlphaClipThreshold",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "e280e8ba3f4146aca7c353782ea8c79e"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.AlphaClipThreshold"
 }
 
 {
@@ -46151,42 +46463,6 @@
         "w": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "e865495b677949199fc7cfe0b2a1e110",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -783.0001220703125,
-            "y": -1477.000244140625,
-            "width": 148.00006103515626,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "601268365a4241319c8a61f6d05a7faf"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "11d17b32be9247d8afb1e081f815bcf8"
-    }
 }
 
 {
@@ -46314,6 +46590,42 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "e8b63c463b4b4a4e8a020233538a3216",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1365.0,
+            "y": -1754.000244140625,
+            "width": 154.0,
+            "height": 34.000244140625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "aa6089b0c5164fc1b52213bfb6f0093a"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "36e132d8adbe43bfb2803632ab726ded"
+    }
 }
 
 {
@@ -46550,29 +46862,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "ea7db4dcfb274a349f12d19fe1bf0633",
-    "m_Id": -571921639,
-    "m_DisplayName": "origin",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_origin",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "ea95702f39534b05be8153afdd62342a",
     "m_Id": 1,
@@ -46717,24 +47006,6 @@
         "w": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
-    "m_ObjectId": "eb7e9cc7835a4c37993339dbf9e16615",
-    "m_Id": 878772836,
-    "m_DisplayName": "texture",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_texture",
-    "m_StageCapability": 2,
-    "m_BareResource": false,
-    "m_Texture": {
-        "m_SerializedTexture": "",
-        "m_Guid": ""
-    },
-    "m_DefaultType": 0
 }
 
 {
@@ -47011,29 +47282,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "ed6534412d7d4d918812af342ecfbfc8",
-    "m_Id": 380768930,
-    "m_DisplayName": "b",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_b",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.SaturateNode",
     "m_ObjectId": "ed8eec61d0f64329a59c08ed42483c2c",
     "m_Group": {
@@ -47068,29 +47316,6 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "edd948eca64349569bb13210ff9fa1a1",
-    "m_Id": -571921639,
-    "m_DisplayName": "origin",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_origin",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -47249,6 +47474,49 @@
     "m_ShaderOutputName": "Sampler",
     "m_StageCapability": 3,
     "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AddNode",
+    "m_ObjectId": "eea85506be6b4e5586acf6f5727fe907",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Add",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -242.0001983642578,
+            "y": -2346.00048828125,
+            "width": 207.99984741210938,
+            "height": 302.000244140625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "b37bed9799374f818ad9be41387ff069"
+        },
+        {
+            "m_Id": "225dbe96f1fc492191395ef947600f53"
+        },
+        {
+            "m_Id": "1978ebc4e2194917adca68b6ac05ed97"
+        }
+    ],
+    "synonyms": [
+        "addition",
+        "sum",
+        "plus"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -47460,6 +47728,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "efdaab6eb41d48d6a696c8e373a86091",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1293.000244140625,
+            "y": -2793.0,
+            "width": 142.999755859375,
+            "height": 33.999755859375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c3641ddce6ac49a39c363ff68feb2c1f"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "ac503bef496344ad8b9dfb5bbb213f9b"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "f00c59ae2d604568943257d37439f60d",
     "m_Id": 1,
@@ -47569,6 +47873,31 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "f07391b25e554854b32928cc6d38f6b8",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
     "m_LiteralMode": false
 }
 
@@ -47783,6 +48112,31 @@
         "w": 0.0
     },
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "f201ed3dbb664a97b7812d505b732824",
+    "m_Id": 1,
+    "m_DisplayName": "Out_Vector4",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "OutVector4",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -48089,29 +48443,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "f3654a1348834940ac00f83248c7aa54",
-    "m_Id": 0,
-    "m_DisplayName": "YCoef",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
     "m_ObjectId": "f379b460e84b4cf186ba25f2a67f16d3",
     "m_Id": 2,
@@ -48198,29 +48529,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "f3e9f5c1cbef4e0495b1d664cd0203e2",
-    "m_Id": 0,
-    "m_DisplayName": "Min",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "f40561932893452eaafc2b7964c920dd",
     "m_Group": {
@@ -48281,22 +48589,6 @@
     "m_Hidden": false,
     "m_ShaderOutputName": "Time",
     "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "f4a06e0a84b84a4baf54af17fdd2ff87",
-    "m_Id": 1426526534,
-    "m_DisplayName": "tile",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_tile",
-    "m_StageCapability": 2,
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": [],
@@ -48371,6 +48663,65 @@
     "m_ShaderOutputName": "Sampler",
     "m_StageCapability": 3,
     "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "f6016fc1cc994c02abf133a689d17d3e",
+    "m_Id": 716731476,
+    "m_DisplayName": "normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_normal",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 1.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "f6385e75584846a5bd6880b61c6d3a8e",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1142.0003662109375,
+            "y": -2286.000244140625,
+            "width": 96.0001220703125,
+            "height": 34.000244140625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "586131ec819b4a389b5f2ea0a7df7af9"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "bac640b190f64590a1e634b743694ff4"
+    }
 }
 
 {
@@ -48594,6 +48945,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "f7b0f343999c4e9fbaed96ec8fa8c710",
+    "m_Id": 1866388063,
+    "m_DisplayName": "a",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_a",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": -1.0,
+        "y": 1.0,
+        "z": -1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "f7e3e88f50a54f688a1b5efb8835f943",
     "m_Id": 3,
@@ -48602,6 +48976,102 @@
     "m_Hidden": false,
     "m_ShaderOutputName": "B",
     "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
+    "m_ObjectId": "f802801104f648089502d979976116e8",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "PLATEAU Lod 1 Triplanar Sub",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -941.000244140625,
+            "y": -1927.0,
+            "width": 243.999755859375,
+            "height": 446.9996337890625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "0c3702fcf1474955897f2ff135bf9bd4"
+        },
+        {
+            "m_Id": "94d54c79807446f89188a747e766bdc0"
+        },
+        {
+            "m_Id": "e62d05b875f147149823d81bb8cd049e"
+        },
+        {
+            "m_Id": "10a78ef473ef409a92f81647ec259f28"
+        },
+        {
+            "m_Id": "bd2335dad9ee4dabb5b762f8dbed1052"
+        },
+        {
+            "m_Id": "ad94e63f798b4736a69b1d64ab11cf2b"
+        },
+        {
+            "m_Id": "7d4f71e317294c948a9e2f051c882416"
+        },
+        {
+            "m_Id": "d10b63ac71a645cbbd03e93ecef0b23e"
+        },
+        {
+            "m_Id": "8b96d9dd2bde458aa64e915f771af0d2"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedSubGraph": "{\n    \"subGraph\": {\n        \"fileID\": -5475051401550479605,\n        \"guid\": \"dddc4c6b563945640a528c2298f6eb80\",\n        \"type\": 3\n    }\n}",
+    "m_PropertyGuids": [
+        "b533a582-e8cf-4db5-8f6d-b7baa6225076",
+        "df3c24b2-12cc-43d9-b0b9-51949afb0c22",
+        "33fa6efa-2a2f-4f4d-bce8-dde070878341",
+        "8c149f45-cd88-4128-9f63-45b4dfc231bc",
+        "39b918d5-46fa-4877-8288-2621ebc7ef05",
+        "079e4f5d-ec91-4bcc-bdd3-073d15ecc876",
+        "0fe1fc72-09ee-4a75-bb76-243e78518e14",
+        "b08c4047-354e-4cb9-a8fe-42a10399c54b"
+    ],
+    "m_PropertyIds": [
+        878772836,
+        716731476,
+        -571921639,
+        -985074803,
+        1426526534,
+        127769700,
+        1866388063,
+        380768930
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "f803068728434e6a988ee74dae3b8d02",
+    "m_Id": 1426526534,
+    "m_DisplayName": "tile",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_tile",
+    "m_StageCapability": 2,
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": [],
@@ -48638,6 +49108,42 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "f89163b270724e249756da6d52195d6e",
+    "m_Group": {
+        "m_Id": "6f3455e5e11545ba83ddff692b6d5f55"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -1148.0001220703125,
+            "y": -1927.0,
+            "width": 149.9998779296875,
+            "height": 33.9996337890625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "84678a8a6dc94e8f92a3e64fffadda4b"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "647a74e6acc74647aff2344abb5e068f"
+    }
 }
 
 {
@@ -48937,6 +49443,7 @@
     "m_BackThenFrontRendering": false,
     "m_TransparentDepthPrepass": false,
     "m_TransparentDepthPostpass": false,
+    "m_TransparentPerPixelSorting": false,
     "m_SupportLodCrossFade": false
 }
 
@@ -49088,8 +49595,8 @@
     "m_ObjectId": "faf854d6c82c4d6fbec041da4f6b58a8",
     "m_Title": "Emmision Map HDRP",
     "m_Position": {
-        "x": 739.9999389648438,
-        "y": 1117.9996337890625
+        "x": 740.0,
+        "y": 1118.000244140625
     }
 }
 
@@ -49225,29 +49732,6 @@
     "m_Property": {
         "m_Id": "8b2aac6655e64db981cfacd006498d38"
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "fbaeee7c17944a4d992b6aef918114ad",
-    "m_Id": 0,
-    "m_DisplayName": "ZCoef",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -49411,25 +49895,20 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "fd26ffba414b40479b20109ee23edf6e",
-    "m_Id": 1866388063,
-    "m_DisplayName": "a",
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "fd2bf01c546249bb9652bd7f27f57b9e",
+    "m_Id": 878772836,
+    "m_DisplayName": "texture",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "_a",
+    "m_ShaderOutputName": "_texture",
     "m_StageCapability": 2,
-    "m_Value": {
-        "x": 1.0,
-        "y": 1.0,
-        "z": 1.0
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "",
+        "m_Guid": ""
     },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
+    "m_DefaultType": 0
 }
 
 {
@@ -49573,42 +50052,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "fe5bb7f79f454ff89e4ec0f4d165ac13",
-    "m_Group": {
-        "m_Id": "268aebd00d0b4e74921a871f08492592"
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -910.9999389648438,
-            "y": -2401.999755859375,
-            "width": 150.0,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "5da36e3b039c479db47217579c40cdfb"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "04052d05f38847259e99e9759f7a5455"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "feac2edc564b452fa3678674c9f87bf2",
     "m_Id": 1,
@@ -49630,29 +50073,6 @@
         "w": 0.0
     },
     "m_LiteralMode": false
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "fec563ab25b548d6b4bbc69b1dcfa3d8",
-    "m_Id": -985074803,
-    "m_DisplayName": "coef",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "_coef",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
 }
 
 {

--- a/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_HDRP.shadergraph
+++ b/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_HDRP.shadergraph
@@ -195,6 +195,9 @@
             "m_Id": "bfa0cf41fd70436491fcd94fb1313a03"
         },
         {
+            "m_Id": "4985ad52e2e5490380687cb06ef7de1c"
+        },
+        {
             "m_Id": "351bb73335a44d568cf12d62be84c501"
         },
         {
@@ -18978,6 +18981,18 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "4985ad52e2e5490380687cb06ef7de1c",
+    "m_Name": "Deprecated",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "0b330496ad4f431c98bb3b70781ddb5c"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "4991ba386d3d4f44bcefd23fd94b8a5a",
     "m_Id": 0,
@@ -23410,8 +23425,8 @@
     "m_ObjectId": "656155abed2648b6bf803e4d5394beca",
     "m_Title": "Fake GI",
     "m_Position": {
-        "x": 25.999998092651368,
-        "y": 3365.999755859375
+        "x": 26.0,
+        "y": 3366.0
     }
 }
 
@@ -27882,7 +27897,7 @@
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.CategoryData",
     "m_ObjectId": "826ad165760a43b5874a8af38f4f8133",
-    "m_Name": "LOD1",
+    "m_Name": "LOD1 (depreccated)",
     "m_ChildObjectList": [
         {
             "m_Id": "8b2aac6655e64db981cfacd006498d38"
@@ -38957,9 +38972,6 @@
             "m_Id": "1c8ba876fd4c44549d7e7585a5cc242d"
         },
         {
-            "m_Id": "0b330496ad4f431c98bb3b70781ddb5c"
-        },
-        {
             "m_Id": "a3b883f42dc44b798507a174915af057"
         },
         {
@@ -40604,7 +40616,7 @@
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.CategoryData",
     "m_ObjectId": "c8d4896e391f4dc2bcc35215c1325aef",
-    "m_Name": "Building Textures",
+    "m_Name": "Building Textures (deprecated)",
     "m_ChildObjectList": [
         {
             "m_Id": "ab4f2c09fd504b9c9f9ff64225201f69"
@@ -49488,7 +49500,7 @@
     "m_Title": "Emmision Map HDRP",
     "m_Position": {
         "x": 740.0,
-        "y": 1117.999755859375
+        "y": 1118.0
     }
 }
 

--- a/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_HDRP.shadergraph.meta
+++ b/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_HDRP.shadergraph.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7b7f652ab880c834895fd4b65df5b1b6
+guid: 543a8891f01966f43af02d9610f09b27
 ScriptedImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_URP.shadergraph
+++ b/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_URP.shadergraph
@@ -37,6 +37,9 @@
             "m_Id": "6e25cf21b19042e7809871a4bed799f9"
         },
         {
+            "m_Id": "05cf5d1033f3478db0fa6a7308303a01"
+        },
+        {
             "m_Id": "3b83e14b846d4ebd9dd712e7c210669a"
         },
         {
@@ -369,9 +372,6 @@
         },
         {
             "m_Id": "5271bfc300d4459d93a3bfd575417044"
-        },
-        {
-            "m_Id": "8ec08d1ee7e5412ba21797d18d85a3f4"
         },
         {
             "m_Id": "346a926dd8ab426b8eedc65ab050cd45"
@@ -1356,6 +1356,9 @@
         },
         {
             "m_Id": "5a84338871ce4cbfb78e3d4dae6986e4"
+        },
+        {
+            "m_Id": "1ac41219bf174d739a9f85d5aaaa4277"
         }
     ],
     "m_GroupDatas": [
@@ -1908,6 +1911,20 @@
                     "m_Id": "7197d351ab0f44398827b0de432ec9eb"
                 },
                 "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "1ac41219bf174d739a9f85d5aaaa4277"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "5271bfc300d4459d93a3bfd575417044"
+                },
+                "m_SlotId": 1341158853
             }
         },
         {
@@ -4722,20 +4739,6 @@
                     "m_Id": "8146d91fb3a1494c89ad02dc99050b78"
                 },
                 "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "8ec08d1ee7e5412ba21797d18d85a3f4"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "5271bfc300d4459d93a3bfd575417044"
-                },
-                "m_SlotId": 1341158853
             }
         },
         {
@@ -8016,6 +8019,22 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "0498ed09685448d8ba23783af08fc668",
+    "m_Id": 0,
+    "m_DisplayName": "WindowTile",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [],
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "04a88aaf68ab4a50abf8a17add332265",
     "m_Id": 5,
     "m_DisplayName": "Blend_z",
@@ -8141,6 +8160,50 @@
         "w": 0.0
     },
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "05cf5d1033f3478db0fa6a7308303a01",
+    "m_Guid": {
+        "m_GuidSerialized": "fac76468-83c4-4e98-810c-9a15e7e02fda"
+    },
+    "promotedFromAssetID": "",
+    "promotedFromCategoryName": "",
+    "promotedOrdering": -1,
+    "m_Name": "WindowTile",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "WindowTile",
+    "m_DefaultReferenceName": "_WindowTile",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_PerRendererData": false,
+    "m_customAttributes": [],
+    "m_Value": 0.20000000298023225,
+    "m_FloatType": 0,
+    "m_LiteralFloatMode": false,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    },
+    "m_SliderType": 0,
+    "m_SliderPower": 3.0,
+    "m_EnumType": 0,
+    "m_CSharpEnumString": "",
+    "m_EnumNames": [
+        "Default"
+    ],
+    "m_EnumValues": [
+        0
+    ]
 }
 
 {
@@ -11485,6 +11548,42 @@
     "m_DefaultValue": 0.0,
     "m_Labels": [],
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "1ac41219bf174d739a9f85d5aaaa4277",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -3175.0,
+            "y": 3138.0,
+            "width": 135.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "0498ed09685448d8ba23783af08fc668"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "05cf5d1033f3478db0fa6a7308303a01"
+    }
 }
 
 {
@@ -18403,7 +18502,7 @@
             "m_Id": "23194ec4875e4b928e423090477f1bdf"
         },
         {
-            "m_Id": "d77aab930a714b9699447f50d86ac852"
+            "m_Id": "05cf5d1033f3478db0fa6a7308303a01"
         },
         {
             "m_Id": "5451c5a8909d41f9b8c43242bc986824"
@@ -31480,42 +31579,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "8ec08d1ee7e5412ba21797d18d85a3f4",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -3129.999755859375,
-            "y": 3125.333251953125,
-            "width": 95.33349609375,
-            "height": 36.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "afc45309dbd34d028d2434ae0796ee42"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "d77aab930a714b9699447f50d86ac852"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "8f1ee701986142078b35800b1788beee",
     "m_Id": 1,
@@ -37203,22 +37266,6 @@
         "z": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "afc45309dbd34d028d2434ae0796ee42",
-    "m_Id": 0,
-    "m_DisplayName": "Tile",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": [],
-    "m_LiteralMode": false
 }
 
 {
@@ -43965,7 +44012,7 @@
     "m_Hidden": false,
     "m_PerRendererData": false,
     "m_customAttributes": [],
-    "m_Value": 0.20000000298023225,
+    "m_Value": 1.0,
     "m_FloatType": 0,
     "m_LiteralFloatMode": false,
     "m_RangeValues": {
@@ -49500,6 +49547,9 @@
         },
         {
             "m_Id": "380bef37fe0941529c427637a8630857"
+        },
+        {
+            "m_Id": "d77aab930a714b9699447f50d86ac852"
         }
     ]
 }

--- a/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_URP.shadergraph
+++ b/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_URP.shadergraph
@@ -1347,6 +1347,12 @@
         },
         {
             "m_Id": "2d5bf09d58ec4721a6c7b3d09f7eda11"
+        },
+        {
+            "m_Id": "3b424054ddd046f88b3395acdf04020a"
+        },
+        {
+            "m_Id": "5a84338871ce4cbfb78e3d4dae6986e4"
         }
     ],
     "m_GroupDatas": [
@@ -2478,6 +2484,34 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "3b424054ddd046f88b3395acdf04020a"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "d4c63cd90b314ac5b7e4e774668beb0f"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "3b424054ddd046f88b3395acdf04020a"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "e2435d38dde8456199b72e39c30dbe93"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "3bbd156ec0b04839b467e1a3de886dad"
                 },
                 "m_SlotId": 0
@@ -2904,7 +2938,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "70a1982d184e46838b8f5a6fa147e437"
+                    "m_Id": "5a84338871ce4cbfb78e3d4dae6986e4"
                 },
                 "m_SlotId": 0
             }
@@ -2918,7 +2952,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "d4c63cd90b314ac5b7e4e774668beb0f"
+                    "m_Id": "70a1982d184e46838b8f5a6fa147e437"
                 },
                 "m_SlotId": 0
             }
@@ -4668,7 +4702,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "e2435d38dde8456199b72e39c30dbe93"
+                    "m_Id": "3b424054ddd046f88b3395acdf04020a"
                 },
                 "m_SlotId": 0
             }
@@ -16531,6 +16565,42 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.RedirectNodeData",
+    "m_ObjectId": "3b424054ddd046f88b3395acdf04020a",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Redirect Node",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 153.87490844726563,
+            "y": -1516.0968017578125,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "5c58867cd6bb4dd5a22595e03513a8c5"
+        },
+        {
+            "m_Id": "b1ac4b68675048cd82dea89a5aedad05"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
     "m_ObjectId": "3b83e14b846d4ebd9dd712e7c210669a",
@@ -17078,8 +17148,8 @@
     "m_ObjectId": "3da33f9aa16f43ce8d1dd33548e6dfaf",
     "m_Title": "Fake GI",
     "m_Position": {
-        "x": 247.0,
-        "y": 2535.0
+        "x": 246.9999542236328,
+        "y": 2470.0
     }
 }
 
@@ -22182,6 +22252,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.RedirectNodeData",
+    "m_ObjectId": "5a84338871ce4cbfb78e3d4dae6986e4",
+    "m_Group": {
+        "m_Id": "3da33f9aa16f43ce8d1dd33548e6dfaf"
+    },
+    "m_Name": "Redirect Node",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 1156.9998779296875,
+            "y": 2529.0,
+            "width": 56.0001220703125,
+            "height": 24.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "a366ec03708b4dbebb66637c7a31061d"
+        },
+        {
+            "m_Id": "661a8614cca04e3e8bab298f6e1508f5"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "5a8f251de74c41cd87e1f771de5cfe82",
     "m_Id": 1,
@@ -22433,6 +22539,31 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "5c58867cd6bb4dd5a22595e03513a8c5",
+    "m_Id": 0,
+    "m_DisplayName": "",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
 }
 
 {
@@ -24097,6 +24228,31 @@
         "w": 0.0
     },
     "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "661a8614cca04e3e8bab298f6e1508f5",
+    "m_Id": 1,
+    "m_DisplayName": "",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": true
 }
 
 {
@@ -27335,7 +27491,7 @@
         "z": 0.0,
         "w": 0.0
     },
-    "m_LiteralMode": true
+    "m_LiteralMode": false
 }
 
 {
@@ -34874,6 +35030,31 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "a366ec03708b4dbebb66637c7a31061d",
+    "m_Id": 0,
+    "m_DisplayName": "",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "a37e98dce7674b44a4c65bdb81bcb476",
     "m_Id": 7,
@@ -37302,6 +37483,31 @@
     "m_Property": {
         "m_Id": "76b705c0a2bb46ef9b83fbbeb98e0035"
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "b1ac4b68675048cd82dea89a5aedad05",
+    "m_Id": 1,
+    "m_DisplayName": "",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
 }
 
 {
@@ -43226,10 +43432,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 1375.199951171875,
-            "y": 2594.39990234375,
-            "width": 56.0001220703125,
-            "height": 24.000244140625
+            "x": 1313.9998779296875,
+            "y": 2528.999755859375,
+            "width": 56.0,
+            "height": 24.0
         }
     },
     "m_Slots": [

--- a/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_URP.shadergraph
+++ b/PlateauToolkit.Rendering/Runtime/Building/Shaders/Building_Lod1Triplanar_URP.shadergraph
@@ -192,6 +192,9 @@
             "m_Id": "bfa0cf41fd70436491fcd94fb1313a03"
         },
         {
+            "m_Id": "16f310d4b2e24f9fb8d389e65131dc06"
+        },
+        {
             "m_Id": "f53b4836895245fdbd15ab2723224a78"
         },
         {
@@ -10949,6 +10952,18 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "16f310d4b2e24f9fb8d389e65131dc06",
+    "m_Name": "Deprecated",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "0b330496ad4f431c98bb3b70781ddb5c"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.RedirectNodeData",
     "m_ObjectId": "1700e840d63c4e519d5c22a211ee7eae",
     "m_Group": {
@@ -17148,7 +17163,7 @@
     "m_ObjectId": "3da33f9aa16f43ce8d1dd33548e6dfaf",
     "m_Title": "Fake GI",
     "m_Position": {
-        "x": 246.9999542236328,
+        "x": 247.0,
         "y": 2470.0
     }
 }
@@ -28892,7 +28907,7 @@
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.CategoryData",
     "m_ObjectId": "826ad165760a43b5874a8af38f4f8133",
-    "m_Name": "LOD1",
+    "m_Name": "LOD1 ((deprecated)",
     "m_ChildObjectList": [
         {
             "m_Id": "8b2aac6655e64db981cfacd006498d38"
@@ -39852,9 +39867,6 @@
             "m_Id": "1c8ba876fd4c44549d7e7585a5cc242d"
         },
         {
-            "m_Id": "0b330496ad4f431c98bb3b70781ddb5c"
-        },
-        {
             "m_Id": "df02d2723aba484285bf967af30a1110"
         },
         {
@@ -41540,7 +41552,7 @@
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.CategoryData",
     "m_ObjectId": "c8d4896e391f4dc2bcc35215c1325aef",
-    "m_Name": "Building Textures",
+    "m_Name": "Building Textures (deprecated)",
     "m_ChildObjectList": [
         {
             "m_Id": "ab4f2c09fd504b9c9f9ff64225201f69"


### PR DESCRIPTION
sample用に作成したzoom level 9 Triplanar shaderの対応をTexture生成でも行えるように。
tileや、Textureが若干おかしかったのでshaderの中身を修正。

検証方法
TileでTexture生成を行った際、
Tile Zoom level9のBuildingのPLATEAULod1TriplanarShaderがBuilding_Lod1Triplanar_URP/HDRPに差し変わること。
Time of Dayを夜にした際に窓の光が表示されること。
Building_Lod1Triplanarのマテリアルに生成前と同じテクスチャが割り当てられること。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 特定のズームレベル9ロドレベル1マテリアルの処理ロジックを改善し、より正確なシェーダー割り当てを実現しました。
  * 建物シェーダーのマッピング動作を最適化し、テクスチャ処理の信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

チケットは以下
https://synesthesias.atlassian.net/browse/CPSDK25-290