### PR TITLE
RightOfWayをインスペクタでオフにしても、インスペクタを開かなければ反映されない問題を修正

### DIFF
--- a/PlateauToolkit.Sandbox/Runtime/RoadNetwork/PlateauSandboxTrafficManager.cs
+++ b/PlateauToolkit.Sandbox/Runtime/RoadNetwork/PlateauSandboxTrafficManager.cs
@@ -94,6 +94,24 @@ namespace PlateauToolkit.Sandbox.RoadNetwork
             return (int)Mathf.Min(numRoads / 2, PlateauSandboxTrafficManagerConstants.NUM_MAX_VEHICLES); // 交差点以外の道路数の半分 or 最大車輛数
         }
 
+        void Awake()
+        {
+            SyncRuntimeFlags();
+        }
+
+        void OnValidate()
+        {
+            SyncRuntimeFlags();
+        }
+
+        /// <summary>
+        /// インスペクタ描画に依存せず、実行時フラグへ設定を反映する。
+        /// </summary>
+        private void SyncRuntimeFlags()
+        {
+            PlateauSandboxTrafficManagerConstants.USE_RIGHT_OF_WAYS_ON_RUNTIME = m_EnableRightOfWays;
+        }
+
         void Start()
         {
             // Tile用処理(読込後にDemをGroundに設定するための処理）


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized lifecycle change that only updates a runtime feature flag; main risk is unintended behavior/performance change if scenes relied on the old stale flag.
> 
> **Overview**
> Fixes a bug where toggling *RightOfWay* in the inspector didn’t affect runtime behavior unless the custom inspector UI was rendered.
> 
> `PlateauSandboxTrafficManager` now applies `m_EnableRightOfWays` to `PlateauSandboxTrafficManagerConstants.USE_RIGHT_OF_WAYS_ON_RUNTIME` in `Awake()` and `OnValidate()` via a new `SyncRuntimeFlags()` helper, making the runtime right-of-way check toggle consistent across editor/runtime flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd98451a5530e9ca6ad4f7ef97501f5bf2d9743b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->