### PR TITLE
Environmentで日付変更した際にエラーになるToolkit側の対応の取り込み

### DIFF
--- a/PlateauToolkit.Rendering/Runtime/DayNightCycle/EnvironmentController.cs
+++ b/PlateauToolkit.Rendering/Runtime/DayNightCycle/EnvironmentController.cs
@@ -684,7 +684,6 @@ namespace PlateauToolkit.Rendering
 
             // Add a virtual tilt to the moon's declination
             double virtualTilt = k_Deg2Rad * 25; // Adjust this value to change the moon's rising and setting time
-            //double dec = Math.Asin(Math.Sin(lng) * Math.Cos(obliquity + virtualTilt) + Math.Cos(lat) * Math.Sin(obliquity + virtualTilt) * Math.Sin(longitude));
             double dec = Math.Asin(Math.Clamp(Math.Sin(lng) * Math.Cos(obliquity + virtualTilt) + Math.Cos(lat) * Math.Sin(obliquity + virtualTilt) * Math.Sin(longitude), -1.0, 1.0));
 
             double h = (k_Deg2Rad * (280.16 + 360.9856235 * julianDate) - lw) - rightAscension;

--- a/PlateauToolkit.Rendering/Runtime/DayNightCycle/EnvironmentController.cs
+++ b/PlateauToolkit.Rendering/Runtime/DayNightCycle/EnvironmentController.cs
@@ -684,7 +684,8 @@ namespace PlateauToolkit.Rendering
 
             // Add a virtual tilt to the moon's declination
             double virtualTilt = k_Deg2Rad * 25; // Adjust this value to change the moon's rising and setting time
-            double dec = Math.Asin(Math.Sin(lng) * Math.Cos(obliquity + virtualTilt) + Math.Cos(lat) * Math.Sin(obliquity + virtualTilt) * Math.Sin(longitude));
+            //double dec = Math.Asin(Math.Sin(lng) * Math.Cos(obliquity + virtualTilt) + Math.Cos(lat) * Math.Sin(obliquity + virtualTilt) * Math.Sin(longitude));
+            double dec = Math.Asin(Math.Clamp(Math.Sin(lng) * Math.Cos(obliquity + virtualTilt) + Math.Cos(lat) * Math.Sin(obliquity + virtualTilt) * Math.Sin(longitude), -1.0, 1.0));
 
             double h = (k_Deg2Rad * (280.16 + 360.9856235 * julianDate) - lw) - rightAscension;
             double altitude = Math.Asin(Math.Sin(phi) * Math.Sin(dec) + Math.Cos(phi) * Math.Cos(dec) * Math.Cos(h));


### PR DESCRIPTION
Environmentで日付変更した際にエラーになるToolkit側の対応の取り込み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 日夜サイクルの月の方向計算において、浮動小数点の丸め誤差による計算エラーを修正しました。環境レンダリングの計算がより安定し、月の動きがより正確に表示されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->